### PR TITLE
feat: add sleeper and yahoo auth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# OAuth client IDs and secrets
+SLEEPER_CLIENT_ID=your_sleeper_client_id
+SLEEPER_CLIENT_SECRET=your_sleeper_client_secret
+SLEEPER_REDIRECT_URI=https://your-domain.com/api/auth/sleeper/callback
+
+YAHOO_CLIENT_ID=your_yahoo_client_id
+YAHOO_CLIENT_SECRET=your_yahoo_client_secret
+YAHOO_REDIRECT_URI=https://your-domain.com/api/auth/yahoo/callback
+
+# Webhook or service handling code exchange
+MAKE_CONNECTOR_URL=https://your-make-webhook.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+.next/
+.env
+.env.local
+.env.*
+!.env.example
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# build output
+out/
+build/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 Minimal Next.js 14 + Tailwind starter with:
 - `/` landing page
 - `/ok` health route
-- `/api/yahoo/start` Yahoo OAuth redirect
-- `/api/yahoo/callback` posts `{ provider:'yahoo', code }` to Make.com webhook
+- `/api/auth/sleeper` Sleeper OAuth redirect
+- `/api/auth/yahoo` Yahoo OAuth redirect
+- `/api/auth/*/callback` posts `{ provider, code }` to Make.com webhook
 
 ## Env vars (Vercel → Project → Settings → Environment Variables)
-- `YAHOO_CLIENT_ID` — from Yahoo Developer app
-- `YAHOO_REDIRECT_URI` — `https://<your-vercel-domain>/api/yahoo/callback`
+- `SLEEPER_CLIENT_ID` / `SLEEPER_CLIENT_SECRET`
+- `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper/callback`
+- `YAHOO_CLIENT_ID` / `YAHOO_CLIENT_SECRET`
+- `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo/callback`
 - `MAKE_CONNECTOR_URL` — your Make "connector.start" webhook URL
 - (optional) `NEXT_PUBLIC_MAKE_CONNECTOR_URL` — same as above if you prefer exposing to client
 
@@ -15,4 +18,4 @@ Minimal Next.js 14 + Tailwind starter with:
 1. Import repo into Vercel (Framework: Next.js)
 2. Leave Root Directory blank (repo root)
 3. Set env vars above and deploy
-4. Test `/ok` and `/api/yahoo/start`
+4. Test `/ok` and `/api/auth/yahoo`

--- a/app/api/auth/sleeper/callback/route.ts
+++ b/app/api/auth/sleeper/callback/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  const makeUrl = process.env.MAKE_CONNECTOR_URL;
+
+  if (makeUrl && code) {
+    fetch(makeUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'sleeper', code }),
+    }).catch(() => {});
+  }
+
+  const next = new URL('/dashboard?connected=sleeper', req.url);
+  if (!code) {
+    next.searchParams.set('warn', 'no_code');
+  }
+  return NextResponse.redirect(next);
+}

--- a/app/api/auth/sleeper/route.ts
+++ b/app/api/auth/sleeper/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const clientId = process.env.SLEEPER_CLIENT_ID;
+  const redirectUri = process.env.SLEEPER_REDIRECT_URI;
+  if (!clientId || !redirectUri) {
+    return NextResponse.json(
+      { ok: false, error: 'Missing SLEEPER_CLIENT_ID or SLEEPER_REDIRECT_URI' },
+      { status: 500 }
+    );
+  }
+
+  const auth = new URL('https://api.sleeper.app/oauth/authorize');
+  auth.searchParams.set('client_id', clientId);
+  auth.searchParams.set('redirect_uri', redirectUri);
+  auth.searchParams.set('response_type', 'code');
+
+  return NextResponse.redirect(auth.toString(), { status: 302 });
+}

--- a/app/api/auth/yahoo/callback/route.ts
+++ b/app/api/auth/yahoo/callback/route.ts
@@ -7,16 +7,13 @@ export async function GET(req: Request) {
   const state = url.searchParams.get('state');
   const cookieState = cookies().get('y_state')?.value;
 
-  // Basic state check (don’t block MVP if absent, just warn)
   if (cookieState && state && cookieState !== state) {
     return NextResponse.redirect(new URL('/dashboard?error=state_mismatch', req.url));
   }
   cookies().delete('y_state');
 
-  // Fire Make CONNECTOR (token exchange happens there)
   const makeUrl = process.env.MAKE_CONNECTOR_URL;
   if (makeUrl && code) {
-    // fire-and-forget; we don't wait for it
     fetch(makeUrl, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -24,10 +21,9 @@ export async function GET(req: Request) {
     }).catch(() => {});
   }
 
-  // Land the user
   const next = new URL('/dashboard?connected=yahoo', req.url);
   if (!code) {
-    next.searchParams.set('warn', 'no_code'); // helps debugging if needed
+    next.searchParams.set('warn', 'no_code');
   }
   return NextResponse.redirect(next);
 }

--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -1,4 +1,3 @@
-// app/api/yahoo/start/route.ts
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import crypto from 'crypto';
@@ -13,7 +12,6 @@ export async function GET(req: Request) {
     );
   }
 
-  // Optional: debug mode shows the URL instead of redirecting
   const debug = new URL(req.url).searchParams.get('debug') === '1';
 
   const state = crypto.randomBytes(16).toString('hex');

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,10 +13,10 @@ export default function Dashboard({
       <div className="container space-y-6">
         <h1 className="text-3xl font-extrabold">Dashboard</h1>
 
-        {connected === 'yahoo' ? (
+        {connected ? (
           <div className="card">
             <p className="text-green-700 font-semibold">
-              ✅ Yahoo connected successfully.
+              ✅ {connected === 'yahoo' ? 'Yahoo' : 'Sleeper'} connected successfully.
             </p>
             <p className="text-sm text-gray-600">
               You can re-connect or fetch last week&apos;s snapshot next.
@@ -27,14 +27,13 @@ export default function Dashboard({
             <p className="text-amber-700 font-semibold">
               No provider connected yet.
             </p>
-            <p className="text-sm text-gray-600">
-              Start with Yahoo below.
-            </p>
+            <p className="text-sm text-gray-600">Start below.</p>
           </div>
         )}
 
         <div className="flex gap-3">
-          <a href="/api/yahoo/start" className="btn">Connect Yahoo</a>
+          <a href="/api/auth/sleeper" className="btn">Connect Sleeper</a>
+          <a href="/api/auth/yahoo" className="btn">Connect Yahoo</a>
           <Link href="/" className="rounded-xl px-5 py-3 border hover:bg-gray-50">
             Back to Home
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,9 +10,12 @@ export default function Home() {
           Connect Sleeper or Yahoo. Get a weekly podcast that roasts your rivals and recaps every clutch move.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <a href="/dashboard" className="btn">Connect your league</a>
-          <a href="/api/yahoo/start" className="rounded-xl px-5 py-3 border hover:bg-gray-50">
-            Connect Yahoo (Beta)
+          <a href="/api/auth/sleeper" className="btn">Connect Sleeper</a>
+          <a
+            href="/api/auth/yahoo"
+            className="rounded-xl px-5 py-3 border hover:bg-gray-50"
+          >
+            Connect Yahoo
           </a>
         </div>
         <p className="text-sm text-gray-500">You’re in control. Disconnect anytime.</p>


### PR DESCRIPTION
## Summary
- add OAuth redirect and callback handlers for Sleeper and Yahoo
- wire home and dashboard connect buttons to new auth routes
- document required SLEEPER_* and YAHOO_* environment variables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b38df6db54832e93bc35e93e2c1396