### PR TITLE
Redirect auth flows to dashboard

### DIFF
--- a/app/api/auth/sleeper/callback/route.ts
+++ b/app/api/auth/sleeper/callback/route.ts
@@ -13,9 +13,29 @@ export async function GET(req: Request) {
     }).catch(() => {});
   }
 
-  const next = new URL('/dashboard?connected=sleeper', req.url);
+  const next = new URL('/dashboard?provider=sleeper', req.url);
   if (!code) {
     next.searchParams.set('warn', 'no_code');
   }
   return NextResponse.redirect(next);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const code = body.code as string | undefined;
+  const makeUrl = process.env.MAKE_CONNECTOR_URL;
+
+  if (makeUrl && code) {
+    fetch(makeUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'sleeper', code }),
+    }).catch(() => {});
+  }
+
+  const res: Record<string, unknown> = { ok: true, provider: 'sleeper' };
+  if (!code) {
+    res.warn = 'no_code';
+  }
+  return NextResponse.json(res);
 }

--- a/app/api/auth/sleeper/route.ts
+++ b/app/api/auth/sleeper/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
 
-export async function GET() {
+export async function GET(req: Request) {
   const clientId = process.env.SLEEPER_CLIENT_ID;
   const redirectUri = process.env.SLEEPER_REDIRECT_URI;
   if (!clientId || !redirectUri) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing SLEEPER_CLIENT_ID or SLEEPER_REDIRECT_URI' },
-      { status: 500 }
+    return NextResponse.redirect(
+      new URL('/dashboard?provider=sleeper', req.url)
     );
   }
 
@@ -16,4 +15,19 @@ export async function GET() {
   auth.searchParams.set('response_type', 'code');
 
   return NextResponse.redirect(auth.toString(), { status: 302 });
+}
+
+export async function POST(req: Request) {
+  const clientId = process.env.SLEEPER_CLIENT_ID;
+  const redirectUri = process.env.SLEEPER_REDIRECT_URI;
+  if (!clientId || !redirectUri) {
+    return NextResponse.json({ ok: true, provider: 'sleeper', stub: true });
+  }
+
+  const auth = new URL('https://api.sleeper.app/oauth/authorize');
+  auth.searchParams.set('client_id', clientId);
+  auth.searchParams.set('redirect_uri', redirectUri);
+  auth.searchParams.set('response_type', 'code');
+
+  return NextResponse.json({ ok: true, auth: auth.toString() });
 }

--- a/app/api/auth/yahoo/callback/route.ts
+++ b/app/api/auth/yahoo/callback/route.ts
@@ -21,9 +21,39 @@ export async function GET(req: Request) {
     }).catch(() => {});
   }
 
-  const next = new URL('/dashboard?connected=yahoo', req.url);
+  const next = new URL('/dashboard?provider=yahoo', req.url);
   if (!code) {
     next.searchParams.set('warn', 'no_code');
   }
   return NextResponse.redirect(next);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const code = body.code as string | undefined;
+  const state = body.state as string | undefined;
+  const cookieState = cookies().get('y_state')?.value;
+
+  if (cookieState && state && cookieState !== state) {
+    return NextResponse.json(
+      { ok: false, error: 'state_mismatch' },
+      { status: 400 }
+    );
+  }
+  cookies().delete('y_state');
+
+  const makeUrl = process.env.MAKE_CONNECTOR_URL;
+  if (makeUrl && code) {
+    fetch(makeUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'yahoo', code }),
+    }).catch(() => {});
+  }
+
+  const res: Record<string, unknown> = { ok: true, provider: 'yahoo' };
+  if (!code) {
+    res.warn = 'no_code';
+  }
+  return NextResponse.json(res);
 }

--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -2,6 +2,17 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import crypto from 'crypto';
 
+function buildAuth(clientId: string, redirectUri: string, state: string) {
+  const auth = new URL('https://api.login.yahoo.com/oauth2/request_auth');
+  auth.searchParams.set('client_id', clientId);
+  auth.searchParams.set('redirect_uri', redirectUri);
+  auth.searchParams.set('response_type', 'code');
+  auth.searchParams.set('scope', 'openid fspt-r');
+  auth.searchParams.set('language', 'en-us');
+  auth.searchParams.set('state', state);
+  return auth;
+}
+
 export async function GET(req: Request) {
   const clientId = process.env.YAHOO_CLIENT_ID;
   const redirectUri = process.env.YAHOO_REDIRECT_URI;
@@ -12,7 +23,28 @@ export async function GET(req: Request) {
     );
   }
 
-  const debug = new URL(req.url).searchParams.get('debug') === '1';
+  const state = crypto.randomBytes(16).toString('hex');
+  cookies().set('y_state', state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 600,
+  });
+
+  const auth = buildAuth(clientId, redirectUri, state);
+  return NextResponse.redirect(auth.toString(), { status: 302 });
+}
+
+export async function POST(req: Request) {
+  const clientId = process.env.YAHOO_CLIENT_ID;
+  const redirectUri = process.env.YAHOO_REDIRECT_URI;
+  if (!clientId || !redirectUri) {
+    return NextResponse.json(
+      { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
+      { status: 500 }
+    );
+  }
 
   const state = crypto.randomBytes(16).toString('hex');
   cookies().set('y_state', state, {
@@ -23,16 +55,6 @@ export async function GET(req: Request) {
     maxAge: 600,
   });
 
-  const auth = new URL('https://api.login.yahoo.com/oauth2/request_auth');
-  auth.searchParams.set('client_id', clientId);
-  auth.searchParams.set('redirect_uri', redirectUri);
-  auth.searchParams.set('response_type', 'code');
-  auth.searchParams.set('scope', 'openid fspt-r');
-  auth.searchParams.set('language', 'en-us');
-  auth.searchParams.set('state', state);
-
-  if (debug) {
-    return NextResponse.json({ ok: true, auth: auth.toString() });
-  }
-  return NextResponse.redirect(auth.toString(), { status: 302 });
+  const auth = buildAuth(clientId, redirectUri, state);
+  return NextResponse.json({ ok: true, auth: auth.toString() });
 }


### PR DESCRIPTION
## Summary
- Redirect Yahoo and Sleeper OAuth callbacks to `/dashboard` with `provider` query parameter.
- Provide POST endpoints for Yahoo and Sleeper auth routes to return JSON for programmatic access.
- Stub Sleeper GET auth route to redirect straight to dashboard when OAuth credentials are missing.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3b914c030832e8d9bcb3252609989