### PR TITLE
Add Sleeper league form and simplify auth

### DIFF
--- a/app/api/auth/sleeper/route.ts
+++ b/app/api/auth/sleeper/route.ts
@@ -1,19 +1,5 @@
 import { NextResponse } from 'next/server';
 
-export async function GET() {
-  const clientId = process.env.SLEEPER_CLIENT_ID;
-  const redirectUri = process.env.SLEEPER_REDIRECT_URI;
-  if (!clientId || !redirectUri) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing SLEEPER_CLIENT_ID or SLEEPER_REDIRECT_URI' },
-      { status: 500 }
-    );
-  }
-
-  const auth = new URL('https://api.sleeper.app/oauth/authorize');
-  auth.searchParams.set('client_id', clientId);
-  auth.searchParams.set('redirect_uri', redirectUri);
-  auth.searchParams.set('response_type', 'code');
-
-  return NextResponse.redirect(auth.toString(), { status: 302 });
+export async function GET(request: Request) {
+  return NextResponse.redirect(new URL('/dashboard?provider=sleeper', request.url));
 }

--- a/app/dashboard/SleeperLeagueForm.tsx
+++ b/app/dashboard/SleeperLeagueForm.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function SleeperLeagueForm() {
+  const [value, setValue] = useState('');
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    let leagueId = value.trim();
+    const match = leagueId.match(/\/league\/(\d+)/);
+    if (match) {
+      leagueId = match[1];
+    }
+
+    const snapshotRes = await fetch('/api/snapshot/fetch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: 'sleeper', leagueId, week: undefined }),
+    });
+    const { week } = await snapshotRes.json();
+
+    const episodeRes = await fetch('/api/episode/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: 'sleeper', leagueId, week }),
+    });
+    const { episodeId } = await episodeRes.json();
+
+    await fetch('/api/episode/render', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ episodeId }),
+    });
+
+    router.push(`/e/${episodeId}`);
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <input
+        type="text"
+        name="league"
+        placeholder="Sleeper League URL or ID"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="rounded-xl px-5 py-3 border w-full"
+      />
+      <button type="submit" className="btn">
+        Use League
+      </button>
+    </form>
+  );
+}
+

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,12 +1,13 @@
-// app/dashboard/page.tsx
 import Link from 'next/link';
+import SleeperLeagueForm from './SleeperLeagueForm';
 
 export default function Dashboard({
   searchParams,
 }: {
-  searchParams?: { connected?: string };
+  searchParams?: { connected?: string; provider?: string };
 }) {
   const connected = searchParams?.connected;
+  const provider = searchParams?.provider;
 
   return (
     <main className="min-h-screen px-6 py-16">
@@ -32,12 +33,18 @@ export default function Dashboard({
         )}
 
         <div className="flex gap-3">
-          <a href="/api/auth/sleeper" className="btn">Connect Sleeper</a>
+          <a href="/dashboard?provider=sleeper" className="btn">Connect Sleeper</a>
           <a href="/api/auth/yahoo" className="btn">Connect Yahoo</a>
           <Link href="/" className="rounded-xl px-5 py-3 border hover:bg-gray-50">
             Back to Home
           </Link>
         </div>
+
+        {provider === 'sleeper' && (
+          <div className="card space-y-3">
+            <SleeperLeagueForm />
+          </div>
+        )}
 
         <p className="text-sm text-gray-400">Health: <a className="underline" href="/ok">/ok</a></p>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-// Server Component
 export default function Home() {
   return (
     <main className="min-h-screen flex items-center justify-center px-6 py-16">
@@ -10,7 +9,7 @@ export default function Home() {
           Connect Sleeper or Yahoo. Get a weekly podcast that roasts your rivals and recaps every clutch move.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <a href="/api/auth/sleeper" className="btn">Connect Sleeper</a>
+          <a href="/dashboard?provider=sleeper" className="btn">Connect Sleeper</a>
           <a
             href="/api/auth/yahoo"
             className="rounded-xl px-5 py-3 border hover:bg-gray-50"

--- a/lib/providers/sleeper.ts
+++ b/lib/providers/sleeper.ts
@@ -1,0 +1,17 @@
+export async function getLeaguesForUsername(username: string, season: number) {
+  const user = await (await fetch(`https://api.sleeper.app/v1/user/${username}`)).json();
+  return await (
+    await fetch(
+      `https://api.sleeper.app/v1/user/${user.user_id}/leagues/nfl/${season}`
+    )
+  ).json();
+}
+
+export async function listLeagues(username: string, season: number) {
+  return getLeaguesForUsername(username, season);
+}
+
+export async function getLeagueWeekData(leagueId: string, week: number) {
+  const url = `https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`;
+  return await (await fetch(url)).json();
+}


### PR DESCRIPTION
## Summary
- Direct Sleeper connect buttons to dashboard without OAuth
- Add Sleeper league form to generate and render episodes
- Provide public Sleeper API helpers
- Remove top-level comments in page components to fix build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3b8f821e0832ea5679d847c9f50cc