### PR TITLE
Handle Yahoo OAuth flow and token exchange

### DIFF
--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -1,0 +1,44 @@
+export interface YahooTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  [key: string]: any;
+}
+
+export async function oauthExchange(code: string): Promise<YahooTokenResponse | null> {
+  const clientId = process.env.YAHOO_CLIENT_ID;
+  const clientSecret = process.env.YAHOO_CLIENT_SECRET;
+  const redirectUri = process.env.YAHOO_REDIRECT_URI;
+  if (!clientId || !clientSecret || !redirectUri) {
+    console.error('Missing Yahoo OAuth env vars');
+    return null;
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  const res = await fetch('https://api.login.yahoo.com/oauth2/get_token', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      authorization: `Basic ${basic}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+    }).toString(),
+  });
+
+  if (!res.ok) {
+    let err: unknown;
+    try {
+      err = await res.json();
+    } catch {
+      err = await res.text();
+    }
+    console.error('Yahoo token exchange failed', res.status, err);
+    return null;
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Handle both Yahoo OAuth redirect and callback in a single route, exchanging codes for tokens and redirecting to dashboard
- Add Yahoo provider implementation with Basic auth token exchange and error logging
- Document Yahoo auth handler and fix build issues caused by an unterminated comment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3b8d28384832e9d96199cd9926838