### PR TITLE
fix: restore globals stylesheet

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-:root { color-scheme: light; }
-body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'; }
-.container { max-width: 72rem; margin-inline: auto; }
-.btn { @apply rounded-xl px-5 py-3 bg-black text-white hover:opacity-90; }
-.card { @apply rounded-2xl border p-5; }
+
+/* Minimal helpers used in JSX */
+.container { max-width: 72rem; margin-left: auto; margin-right: auto; }
+.btn { @apply rounded-xl px-5 py-3 border hover:bg-gray-50 inline-flex items-center justify-center; }
+.card { @apply rounded-2xl shadow-sm border p-4; }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 // app/layout.tsx
-import "../styles/globals.css";
+import "./globals.css";
 import type { ReactNode } from "react";
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- import app-level `globals.css` from root layout
- define Tailwind base utilities and helper classes in new stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3c6436b7c832e999256336dc83829