### PR TITLE
feat: improve Yahoo OAuth flow

### DIFF
--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -1,4 +1,6 @@
 // app/api/auth/yahoo/route.ts
+export const runtime = 'nodejs';
+
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getOrCreateUid } from '../../../../lib/user';
@@ -7,16 +9,13 @@ import { encryptToken } from '../../../../lib/security';
 import { getSupabaseAdmin } from '../../../../lib/db';
 import { track } from '../../../../lib/metrics';
 
-// Force Node runtime (Yahoo provider helpers may use Buffer/Node APIs)
-export const runtime = 'nodejs';
-
 /** Build Yahoo OAuth authorize URL */
 function buildAuth(clientId: string, redirectUri: string, state: string) {
   const auth = new URL('https://api.login.yahoo.com/oauth2/request_auth');
   auth.searchParams.set('client_id', clientId);
   auth.searchParams.set('redirect_uri', redirectUri);
   auth.searchParams.set('response_type', 'code');
-  auth.searchParams.set('scope', 'openid fspt-r');
+  auth.searchParams.set('scope', 'openid fspt-r'); // Fantasy Sports read
   auth.searchParams.set('language', 'en-us');
   auth.searchParams.set('state', state);
   return auth;
@@ -29,94 +28,78 @@ function buildAuth(clientId: string, redirectUri: string, state: string) {
  * Supports ?debug=1 to return the built URL as JSON instead of redirect.
  */
 export async function GET(req: NextRequest) {
-  try {
-    const clientId = process.env.YAHOO_CLIENT_ID;
-    const redirectUri = process.env.YAHOO_REDIRECT_URI;
+  const clientId = process.env.YAHOO_CLIENT_ID;
+  const redirectUri = process.env.YAHOO_REDIRECT_URI;
 
-    if (!clientId || !redirectUri) {
-      return NextResponse.json(
-        { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
-        { status: 500 }
-      );
-    }
-
-    const url = new URL(req.url);
-    const code = url.searchParams.get('code');
-    const debug = url.searchParams.get('debug') === '1';
-
-    // --- Callback branch ---
-    if (code) {
-      const stateParam = url.searchParams.get('state');
-      const userIdParam = url.searchParams.get('userId');
-      const { uid: cookieUid } = getOrCreateUid(req);
-      const uid = userIdParam ?? stateParam ?? cookieUid ?? null;
-
-      try {
-        const tokens = await oauthExchange(code);
-        if (tokens && uid) {
-          const supabase = getSupabaseAdmin();
-          const access_enc = await encryptToken(tokens.access_token);
-          const refresh_enc = tokens.refresh_token
-            ? await encryptToken(tokens.refresh_token)
-            : null;
-          const expires_at = tokens.expires_in
-            ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
-            : null;
-
-          const { error } = await supabase.from('league_connection').upsert({
-            user_id: uid,
-            provider: 'yahoo',
-            access_token_enc: access_enc,
-            refresh_token_enc: refresh_enc,
-            expires_at,
-          });
-
-          if (error) {
-            console.error('Supabase upsert error (yahoo tokens):', error);
-          } else {
-            try {
-              track?.('oauth_success', uid, { provider: 'yahoo' });
-            } catch (e) {
-              console.warn('track(oauth_success) failed:', e);
-            }
-          }
-        }
-      } catch (err) {
-        console.error('Yahoo oauthExchange failed:', err);
-      }
-
-      return NextResponse.redirect(new URL('/dashboard?provider=yahoo', req.url));
-    }
-
-    // --- Start-auth branch ---
-    const userIdParam = url.searchParams.get('userId');
-    const { uid, headers } = getOrCreateUid(req);
-    const state = userIdParam ?? uid;
-
-    const auth = buildAuth(clientId, redirectUri, state);
-
-    if (debug) {
-      return new NextResponse(
-        JSON.stringify({ ok: true, auth: auth.toString(), state }),
-        {
-          status: 200,
-          headers: { 'content-type': 'application/json', ...(headers ?? {}) },
-        }
-      );
-    }
-
-    return new NextResponse(null, {
-      status: 302,
-      headers: { Location: auth.toString(), ...(headers ?? {}) },
-    });
-  } catch (err: any) {
-    console.error('Yahoo auth route error:', err);
-    // Show the actual error message for debugging
+  if (!clientId || !redirectUri) {
     return NextResponse.json(
-      { ok: false, error: err?.message || String(err) },
+      { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
       { status: 500 }
     );
   }
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  const debug = url.searchParams.get('debug') === '1';
+
+  // --- Callback branch ---
+  if (code) {
+    const stateParam = url.searchParams.get('state');
+    const userIdParam = url.searchParams.get('userId');
+    const { uid: cookieUid } = getOrCreateUid(req);
+    const uid = userIdParam ?? stateParam ?? cookieUid ?? null;
+
+    try {
+      const tokens = await oauthExchange(code); // implemented in lib/providers/yahoo.ts
+      if (tokens && uid) {
+        const supabase = getSupabaseAdmin();
+        const access_enc = await encryptToken(tokens.access_token);
+        const refresh_enc = tokens.refresh_token
+          ? await encryptToken(tokens.refresh_token)
+          : null;
+        const expires_at = tokens.expires_in
+          ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+          : null;
+
+        const { error } = await supabase.from('league_connection').upsert({
+          user_id: uid,
+          provider: 'yahoo',
+          access_token_enc: access_enc,
+          refresh_token_enc: refresh_enc,
+          expires_at,
+        });
+        if (error) {
+          console.error('Supabase upsert error (yahoo tokens):', error);
+        } else {
+          track?.('oauth_success', uid, { provider: 'yahoo' });
+        }
+      }
+    } catch (err) {
+      console.error('Yahoo oauthExchange failed:', err);
+      // Continue; can surface a UI toast via query params later
+    }
+
+    return NextResponse.redirect(new URL('/dashboard?provider=yahoo', req.url));
+  }
+
+  // --- Start-auth branch ---
+  const userIdParam = url.searchParams.get('userId');
+  const { uid, headers } = getOrCreateUid(req);
+  const state = userIdParam ?? uid;
+
+  const auth = buildAuth(clientId, redirectUri, state);
+
+  if (debug) {
+    return new NextResponse(
+      JSON.stringify({ ok: true, auth: auth.toString(), state }),
+      { status: 200, headers: { 'content-type': 'application/json', ...(headers ?? {}) } }
+    );
+  }
+
+  return new NextResponse(null, {
+    status: 302,
+    headers: { Location: auth.toString(), ...(headers ?? {}) },
+  });
 }
 
 /**
@@ -124,32 +107,21 @@ export async function GET(req: NextRequest) {
  * Return the built authorize URL as JSON (no redirect).
  */
 export async function POST(req: NextRequest) {
-  try {
-    const clientId = process.env.YAHOO_CLIENT_ID;
-    const redirectUri = process.env.YAHOO_REDIRECT_URI;
+  const clientId = process.env.YAHOO_CLIENT_ID;
+  const redirectUri = process.env.YAHOO_REDIRECT_URI;
 
-    if (!clientId || !redirectUri) {
-      return NextResponse.json(
-        { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
-        { status: 500 }
-      );
-    }
-
-    const { uid, headers } = getOrCreateUid(req);
-    const auth = buildAuth(clientId, redirectUri, uid);
-
-    return new NextResponse(
-      JSON.stringify({ ok: true, auth: auth.toString(), state: uid }),
-      {
-        status: 200,
-        headers: { 'content-type': 'application/json', ...(headers ?? {}) },
-      }
-    );
-  } catch (err: any) {
-    console.error('Yahoo auth POST error:', err);
+  if (!clientId || !redirectUri) {
     return NextResponse.json(
-      { ok: false, error: err?.message || String(err) },
+      { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
       { status: 500 }
     );
   }
+
+  const { uid, headers } = getOrCreateUid(req);
+  const auth = buildAuth(clientId, redirectUri, uid);
+
+  return new NextResponse(
+    JSON.stringify({ ok: true, auth: auth.toString(), state: uid }),
+    { status: 200, headers: { 'content-type': 'application/json', ...(headers ?? {}) } }
+  );
 }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,117 +1,43 @@
-// lib/providers/yahoo.ts
+import type { NextRequest } from 'next/server';
 
-const FANTASY_API = "https://fantasysports.yahooapis.com/fantasy/v2";
-const TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
-
-export interface YahooTokenResponse {
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: number;
-  token_type?: string;
-  [key: string]: any;
-}
-
-/**
- * Exchange an authorization code for tokens.
- */
-export async function oauthExchange(code: string): Promise<YahooTokenResponse> {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const clientSecret = process.env.YAHOO_CLIENT_SECRET;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
-    throw new Error("Missing Yahoo OAuth env vars");
-  }
-
-  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
-
-  const res = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "content-type": "application/x-www-form-urlencoded",
-      authorization: `Basic ${basic}`,
-    },
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code,
-      redirect_uri: redirectUri,
-    }).toString(),
+function parseCookie(cookieHeader: string | null): Record<string, string> {
+  if (!cookieHeader) return {};
+  const out: Record<string, string> = {};
+  cookieHeader.split(';').forEach(part => {
+    const [k, ...rest] = part.trim().split('=');
+    if (!k) return;
+    out[k] = decodeURIComponent(rest.join('=') ?? '');
   });
-
-  if (!res.ok) {
-    let err: unknown;
-    try { err = await res.json(); } catch { err = await res.text(); }
-    console.error("Yahoo token exchange failed", res.status, err);
-    throw new Error("yahoo_oauth_exchange_failed");
-  }
-
-  return res.json();
+  return out;
 }
 
 /**
- * Refresh an access token using a refresh_token.
+ * Returns a durable anonymous user id and headers to persist it.
+ * Usage:
+ *   const { uid, headers } = getOrCreateUid(req);
+ *   return NextResponse.redirect(url, { headers });
  */
-export async function refreshToken(refresh_token: string): Promise<YahooTokenResponse> {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const clientSecret = process.env.YAHOO_CLIENT_SECRET;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
-    throw new Error("Missing Yahoo OAuth env vars");
-  }
+export function getOrCreateUid(
+  req: NextRequest
+): { uid: string; headers: Record<string, string> } {
+  const cookies = parseCookie(req.headers.get('cookie'));
+  const existing = cookies['uid'];
 
-  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const uid =
+    existing ||
+    (globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`);
 
-  const res = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "content-type": "application/x-www-form-urlencoded",
-      authorization: `Basic ${basic}`,
-    },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token,
-      redirect_uri: redirectUri,
-    }).toString(),
-  });
+  const cookie = [
+    `uid=${encodeURIComponent(uid)}`,
+    'Path=/',
+    'SameSite=Lax',
+    'HttpOnly',
+    'Secure',
+    `Max-Age=${60 * 60 * 24 * 365}`,
+  ].join('; ');
 
-  if (!res.ok) {
-    let err: unknown;
-    try { err = await res.json(); } catch { err = await res.text(); }
-    console.error("Yahoo refresh failed", res.status, err);
-    throw new Error("yahoo_refresh_failed");
-  }
-
-  return res.json();
-}
-
-/**
- * Example: list the current user's NFL leagues.
- * NOTE: Yahoo Fantasy API is deeply nested JSON; you may need to adjust parsing.
- */
-export async function listLeagues(accessToken: string) {
-  const res = await fetch(
-    `${FANTASY_API}/users;use_login=1/games;game_keys=nfl/leagues?format=json`,
-    { headers: { Authorization: `Bearer ${accessToken}` } }
-  );
-  if (!res.ok) throw new Error("yahoo_listLeagues_failed");
-  const data = await res.json();
-
-  // TODO: parse data.fantasy_content safely to extract leagues
-  return data;
-}
-
-/**
- * Example: get scoreboard for a league/week.
- * Returns raw JSON — normalize downstream.
- */
-export async function getLeagueWeekData(
-  accessToken: string,
-  leagueId: string,
-  week: number
-) {
-  const res = await fetch(
-    `${FANTASY_API}/league/${leagueId}/scoreboard;week=${week}?format=json`,
-    { headers: { Authorization: `Bearer ${accessToken}` } }
-  );
-  if (!res.ok) throw new Error("yahoo_getLeagueWeekData_failed");
-  return res.json();
+  return {
+    uid,
+    headers: { 'Set-Cookie': cookie },
+  };
 }


### PR DESCRIPTION
## Summary
- add durable uid cookie helper for anonymous users
- rewrite Yahoo OAuth route with Node runtime and token upsert

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b5f6df90f4832e9923c263cf5cd90b