### PR TITLE
Harden leagues API and sanitize dashboard errors

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -25,7 +25,15 @@ export default function Dashboard() {
           if (!json.ok) throw new Error(json.error || "Failed to load leagues");
           setLeagues(Array.isArray(json.leagues) ? json.leagues : []);
         })
-        .catch((e) => setError(e.message));
+        .catch((e) => {
+          // If server sent { ok:false, error:'internal_error:STAGE' }, show that.
+          // Otherwise show a generic message.
+          if (typeof e?.message === "string") {
+            setError(e.message);
+          } else {
+            setError("internal_error:unknown");
+          }
+        });
     }
   }, [provider]);
 


### PR DESCRIPTION
## Summary
- replace `/api/leagues/list` with staged, non-leaking error handler
- guard dashboard league fetch errors with generic fallback

## Testing
- `npx tsx -e "import m from './app/api/leagues/list/route'; import { NextRequest } from 'next/server'; const req = new NextRequest('http://localhost/api/leagues/list?provider=yahoo'); m.GET(req).then(async res => { console.log('status', res.status); console.log('body', await res.text()); });"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b61b00c468832e8c53db8e59a1634d