### PR TITLE
feat: add sleeper provider and studio UI

### DIFF
--- a/app/(studio)/StudioClient.tsx
+++ b/app/(studio)/StudioClient.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import type { LeagueMeta, MatchupWeek } from '../../types/domain';
+import { selectLeague, loadLastWeek } from './actions';
+
+interface Props {
+  demoUsername?: string;
+}
+
+export default function StudioClient({ demoUsername = '' }: Props) {
+  const [username, setUsername] = useState(demoUsername);
+  const [leagues, setLeagues] = useState<LeagueMeta[]>([]);
+  const [selected, setSelected] = useState<LeagueMeta | null>(null);
+  const [week, setWeek] = useState<MatchupWeek | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const fetchLeagues = async () => {
+    try {
+      setError(null);
+      const res = await fetch('/api/providers/sleeper/leagues', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username }),
+      });
+      if (!res.ok) throw new Error('failed');
+      const data: LeagueMeta[] = await res.json();
+      setLeagues(data);
+    } catch (e) {
+      setError('Failed to load leagues');
+    }
+  };
+
+  const handleSelect = (leagueId: string) => {
+    const meta = leagues.find((l) => l.leagueId === leagueId);
+    if (meta) {
+      startTransition(() => selectLeague(meta));
+      setSelected(meta);
+    }
+  };
+
+  const handleFetchWeek = () => {
+    if (!selected) return;
+    startTransition(async () => {
+      const data = await loadLastWeek(selected.leagueId);
+      setWeek(data);
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-x-2">
+        <input
+          className="border px-3 py-2"
+          placeholder="Sleeper username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <button onClick={fetchLeagues} className="btn">Fetch leagues</button>
+      </div>
+      {error && <p className="text-red-600">{error}</p>}
+      {leagues.length > 0 && (
+        <select
+          className="border px-3 py-2"
+          onChange={(e) => handleSelect(e.target.value)}
+          defaultValue=""
+        >
+          <option value="" disabled>
+            Select a league
+          </option>
+          {leagues.map((l) => (
+            <option key={l.leagueId} value={l.leagueId}>
+              {l.name} ({l.season})
+            </option>
+          ))}
+        </select>
+      )}
+      {selected && (
+        <div className="space-y-2">
+          <div className="sticky top-0 bg-white py-2 font-medium">
+            {selected.name} – {selected.season}
+          </div>
+          <button onClick={handleFetchWeek} className="btn">
+            Fetch last week
+          </button>
+        </div>
+      )}
+      {week && (
+        <div className="border p-4 rounded space-y-1">
+          <div>Week {week.week}</div>
+          <div>Top scorer: {week.summary.topScorerTeamId} ({week.summary.topScorerPoints})</div>
+          <div>Biggest blowout: {week.summary.biggestBlowoutGameId}</div>
+          <div>Closest game: {week.summary.closestGameId}</div>
+          <button
+            onClick={() => {
+              fetch('/api/rick/draft', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(week),
+              });
+            }}
+            className="btn"
+          >
+            Send to Rick
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(studio)/actions.ts
+++ b/app/(studio)/actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { revalidateTag } from 'next/cache';
+import type { LeagueMeta, MatchupWeek } from '../../types/domain';
+import { getLeagueWeek, resolveLastCompletedWeek } from '../../lib/providers/sleeper';
+import { tagLeague, tagLeagueWeek } from '../../lib/cache/tags';
+
+export async function selectLeague(meta: LeagueMeta) {
+  cookies().set('selected-league', JSON.stringify(meta), {
+    httpOnly: true,
+    path: '/',
+  });
+  revalidateTag(tagLeague(meta.leagueId));
+}
+
+export async function loadLastWeek(leagueId: string): Promise<MatchupWeek> {
+  const week = resolveLastCompletedWeek(new Date().getFullYear());
+  const { domain } = await getLeagueWeek(leagueId, week);
+  revalidateTag(tagLeagueWeek(leagueId, week));
+  return domain;
+}

--- a/app/(studio)/page.tsx
+++ b/app/(studio)/page.tsx
@@ -1,0 +1,11 @@
+import StudioClient from './StudioClient';
+
+export default function Page() {
+  const demo = process.env.DEMO_MODE === 'true';
+  const demoUsername = demo ? 'demo' : '';
+  return (
+    <main className="p-6">
+      <StudioClient demoUsername={demoUsername} />
+    </main>
+  );
+}

--- a/app/api/providers/sleeper/leagues/route.ts
+++ b/app/api/providers/sleeper/leagues/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getUserIdByUsername, getLeaguesForUser } from '../../../../../lib/providers/sleeper';
+
+const Body = z.object({ username: z.string(), season: z.number().optional() });
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { username, season } = Body.parse(body);
+  const userId = await getUserIdByUsername(username);
+  const leagues = await getLeaguesForUser(userId, season ?? new Date().getFullYear());
+  return NextResponse.json(leagues);
+}

--- a/app/api/providers/sleeper/user/[username]/route.ts
+++ b/app/api/providers/sleeper/user/[username]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getUserIdByUsername } from '../../../../../lib/providers/sleeper';
+
+export async function GET(_req: Request, { params }: { params: { username: string } }) {
+  const userId = await getUserIdByUsername(params.username);
+  return NextResponse.json({ userId });
+}

--- a/app/api/providers/sleeper/week/route.ts
+++ b/app/api/providers/sleeper/week/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getLeagueWeek, resolveLastCompletedWeek } from '../../../../../lib/providers/sleeper';
+
+const Body = z.object({ leagueId: z.string(), week: z.number().optional() });
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { leagueId, week } = Body.parse(body);
+  const targetWeek = week ?? resolveLastCompletedWeek(new Date().getFullYear());
+  const { domain } = await getLeagueWeek(leagueId, targetWeek);
+  return NextResponse.json(domain);
+}

--- a/app/api/rick/draft/route.ts
+++ b/app/api/rick/draft/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { ZMatchupWeek } from '../../../../lib/schemas';
+import type { EpisodeDraft } from '../../../../types/domain';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const parsed = ZMatchupWeek.parse(body);
+  const draft: EpisodeDraft = {
+    leagueId: parsed.league.leagueId,
+    week: parsed.week,
+    outline: ['intro', 'highlights', 'wrap'],
+    scriptMarkdown: `# Week ${parsed.week} Recap`,
+  };
+  return NextResponse.json(draft);
+}

--- a/app/sentry.client.config.ts
+++ b/app/sentry.client.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
+  tracesSampleRate: 1.0,
+});

--- a/app/sentry.server.config.ts
+++ b/app/sentry.server.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN || '',
+  tracesSampleRate: 1.0,
+});

--- a/e2e/demo.spec.ts
+++ b/e2e/demo.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('Rick Tells')).toBeVisible();
+});

--- a/lib/cache/tags.ts
+++ b/lib/cache/tags.ts
@@ -1,0 +1,2 @@
+export const tagLeague = (leagueId: string) => `league:${leagueId}`;
+export const tagLeagueWeek = (leagueId: string, week: number) => `${tagLeague(leagueId)}:week:${week}`;

--- a/lib/http/safeFetch.ts
+++ b/lib/http/safeFetch.ts
@@ -1,0 +1,33 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export class FetchError extends Error {
+  constructor(public code: string, message: string, public status: number) {
+    super(message);
+  }
+}
+
+export async function safeFetch<T>(url: string, init: RequestInit = {}): Promise<T> {
+  const maxAttempts = 3;
+  let attempt = 0;
+  const requestId = (init.headers as any)?.['x-request-id'] || crypto.randomUUID();
+  const headers = { ...(init.headers || {}), 'x-request-id': requestId } as Record<string, string>;
+  while (attempt < maxAttempts) {
+    const res = await fetch(url, { ...init, headers });
+    if (res.status === 429 || res.status >= 500) {
+      attempt++;
+      const delay = Math.pow(2, attempt) * 100 + Math.random() * 100;
+      await sleep(delay);
+      continue;
+    }
+    if (!res.ok) {
+      throw new FetchError('http_error', `Request failed with ${res.status}`, res.status);
+    }
+    try {
+      const json = (await res.json()) as T;
+      return json;
+    } catch (e) {
+      throw new FetchError('invalid_json', 'Failed to parse JSON', res.status);
+    }
+  }
+  throw new FetchError('max_retries', 'Exceeded retry attempts', 500);
+}

--- a/lib/providers/sleeper.ts
+++ b/lib/providers/sleeper.ts
@@ -1,38 +1,200 @@
-// lib/providers/sleeper.ts
+import { safeFetch } from "../http/safeFetch";
+import {
+  ZSleeperUser,
+  ZSleeperLeague,
+  ZSleeperMatchup,
+  ZSleeperRoster,
+  ZSleeperUserMap,
+  ZMatchupWeek,
+} from "../schemas";
+import type { LeagueMeta, MatchupWeek, Team, RosterSpot, Matchup } from "../../types/domain";
+import { z } from "zod";
 
 const API = "https://api.sleeper.app/v1";
 
-/**
- * Get all leagues for a given Sleeper username in a specific season.
- */
-export async function getLeaguesForUsername(username: string, season: number) {
-  const userRes = await fetch(`${API}/user/${encodeURIComponent(username)}`);
-  if (!userRes.ok) throw new Error("failed_to_fetch_user");
-  const user = await userRes.json();
-  if (!user?.user_id) return [];
-
-  const leaguesRes = await fetch(
-    `${API}/user/${user.user_id}/leagues/nfl/${season}`
-  );
-  if (!leaguesRes.ok) throw new Error("failed_to_fetch_leagues");
-  return leaguesRes.json();
+export async function getUserIdByUsername(username: string): Promise<string> {
+  const json = await safeFetch(`${API}/user/${encodeURIComponent(username)}`);
+  const parsed = ZSleeperUser.parse(json);
+  return parsed.user_id;
 }
 
-/**
- * listLeagues: simple wrapper to fetch leagues for a user+season.
- * Kept as a separate export to match existing call sites.
- */
-export async function listLeagues(username: string, season: number) {
-  return getLeaguesForUsername(username, season);
+export async function getLeaguesForUser(
+  userId: string,
+  season: number
+): Promise<LeagueMeta[]> {
+  const json = await safeFetch(`${API}/user/${userId}/leagues/nfl/${season}`);
+  const leagues = z.array(ZSleeperLeague).parse(json);
+  return leagues.map((l) => ({
+    platform: "sleeper" as const,
+    leagueId: l.league_id,
+    season: l.season,
+    name: l.name,
+  }));
 }
 
-/**
- * Fetch matchup data for a given league/week.
- * Returns the raw JSON response (normalization is done downstream).
- */
-export async function getLeagueWeekData(leagueId: string, week: number) {
-  const url = `${API}/league/${leagueId}/matchups/${week}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error("failed_to_fetch_week_data");
-  return res.json();
+export function resolveLastCompletedWeek(
+  season: number,
+  now: Date = new Date()
+): number {
+  const seasonStart = new Date(Date.UTC(season, 8, 7)); // Sep 7 approx week1 start
+  const diff = now.getTime() - seasonStart.getTime();
+  if (diff < 0) return 0;
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  let week = Math.floor(diff / weekMs) + 1;
+  const day = now.getUTCDay();
+  if (day === 0 || day === 1 || (day === 2 && now.getUTCHours() < 8)) {
+    week -= 1;
+  }
+  if (week < 0) week = 0;
+  if (week > 18) week = 18;
+  return week;
+}
+
+export async function getLeagueWeek(leagueId: string, week: number) {
+  const [leagueJson, matchupsJson, rostersJson, usersJson] = await Promise.all([
+    safeFetch(`${API}/league/${leagueId}`),
+    safeFetch(`${API}/league/${leagueId}/matchups/${week}`),
+    safeFetch(`${API}/league/${leagueId}/rosters`),
+    safeFetch(`${API}/league/${leagueId}/users`),
+  ]);
+
+  const leagueParsed = ZSleeperLeague.pick({
+    league_id: true,
+    name: true,
+    season: true,
+  }).parse(leagueJson);
+
+  const matchups = z.array(ZSleeperMatchup).parse(matchupsJson);
+  const rosters = z.array(ZSleeperRoster).parse(rostersJson);
+  const users = z.array(ZSleeperUserMap).parse(usersJson);
+
+  const league: LeagueMeta = {
+    platform: "sleeper",
+    leagueId: leagueId,
+    season: leagueParsed.season,
+    name: leagueParsed.name,
+  };
+
+  const domain = toDomain(league, week, { matchups, rosters, users });
+  return { raw: { matchups, rosters, users }, domain };
+}
+
+export function toDomain(
+  league: LeagueMeta,
+  week: number,
+  raw: {
+    matchups: z.infer<typeof ZSleeperMatchup>[];
+    rosters: z.infer<typeof ZSleeperRoster>[];
+    users: z.infer<typeof ZSleeperUserMap>[];
+  }
+): MatchupWeek {
+  const teamMap = new Map<number, Team>();
+  const userMap = new Map<string, z.infer<typeof ZSleeperUserMap>>();
+  raw.users.forEach((u) => userMap.set(u.user_id, u));
+  raw.rosters.forEach((r) => {
+    const user = userMap.get(r.owner_id);
+    const displayName = user?.display_name || user?.username || `Team ${r.roster_id}`;
+    const team: Team = {
+      teamId: String(r.roster_id),
+      displayName,
+      ownerUserId: r.owner_id,
+    };
+    teamMap.set(r.roster_id, team);
+  });
+
+  // Group matchups by matchup_id
+  const grouped: Record<number, z.infer<typeof ZSleeperMatchup>[]> = {};
+  raw.matchups.forEach((m) => {
+    if (!grouped[m.matchup_id]) grouped[m.matchup_id] = [];
+    grouped[m.matchup_id].push(m);
+  });
+
+  const matchups: Matchup[] = Object.values(grouped).map((pair) => {
+    const [a, b] = pair;
+    const home = a;
+    const away = b;
+    const homeTeamId = String(home.roster_id);
+    const awayTeamId = String(away.roster_id);
+
+    const buildRoster = (m: z.infer<typeof ZSleeperMatchup>): RosterSpot[] => {
+      const starters = m.starters.map((p) => ({
+        slot: "FLEX",
+        playerId: p,
+        points: m.players_points[p] ?? 0,
+      }));
+      const benchPlayers = m.players
+        .filter((p) => !m.starters.includes(p))
+        .map((p) => ({ slot: "BN", playerId: p, points: m.players_points[p] ?? 0 }));
+      return [...starters, ...benchPlayers];
+    };
+
+    const homePoints = home.points;
+    const awayPoints = away.points;
+    let winner: "home" | "away" | "tie" = "tie";
+    if (homePoints > awayPoints) winner = "home";
+    else if (awayPoints > homePoints) winner = "away";
+    const margin = Math.abs(homePoints - awayPoints);
+    return {
+      id: `${homeTeamId}-${awayTeamId}-${week}`,
+      week,
+      homeTeamId,
+      awayTeamId,
+      homePoints,
+      awayPoints,
+      homeRoster: buildRoster(home),
+      awayRoster: buildRoster(away),
+      winner,
+      margin,
+    };
+  });
+
+  let topScorerTeamId = "";
+  let topScorerPoints = -1;
+  matchups.forEach((m) => {
+    if (m.homePoints > topScorerPoints) {
+      topScorerPoints = m.homePoints;
+      topScorerTeamId = m.homeTeamId;
+    }
+    if (m.awayPoints > topScorerPoints) {
+      topScorerPoints = m.awayPoints;
+      topScorerTeamId = m.awayTeamId;
+    }
+  });
+
+  let biggestBlowoutGameId: string | null = null;
+  let closestGameId: string | null = null;
+  let maxMargin = -1;
+  let minMargin = Number.MAX_SAFE_INTEGER;
+  matchups.forEach((m) => {
+    if (m.margin > maxMargin) {
+      maxMargin = m.margin;
+      biggestBlowoutGameId = m.id;
+    }
+    if (m.margin < minMargin) {
+      minMargin = m.margin;
+      closestGameId = m.id;
+    }
+  });
+
+  const summary = {
+    topScorerTeamId,
+    topScorerPoints,
+    biggestBlowoutGameId,
+    closestGameId,
+  };
+
+  const domain: MatchupWeek = {
+    platform: "sleeper",
+    league,
+    generatedAt: new Date().toISOString(),
+    week,
+    teams: Array.from(teamMap.values()),
+    matchups,
+    summary,
+    weeklyAwards: [
+      { key: "top_scorer", label: "Top Scorer", teamId: topScorerTeamId, value: topScorerPoints },
+    ],
+  };
+  ZMatchupWeek.parse(domain); // ensure structure
+  return domain;
 }

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export const ZSleeperUser = z.object({
+  user_id: z.string(),
+  username: z.string(),
+  display_name: z.string().optional(),
+});
+
+export const ZSleeperLeague = z.object({
+  league_id: z.string(),
+  name: z.string(),
+  season: z.coerce.number(),
+});
+
+export const ZSleeperMatchup = z.object({
+  matchup_id: z.number(),
+  roster_id: z.number(),
+  points: z.number().default(0),
+  starters: z.array(z.string()).default([]),
+  players: z.array(z.string()).default([]),
+  players_points: z.record(z.number()).default({}),
+});
+
+export const ZSleeperRoster = z.object({
+  roster_id: z.number(),
+  owner_id: z.string(),
+});
+
+export const ZSleeperUserMap = z.object({
+  user_id: z.string(),
+  username: z.string(),
+  display_name: z.string().optional(),
+});
+
+export const ZRosterSpot = z.object({
+  slot: z.string(),
+  playerId: z.string(),
+  points: z.number(),
+});
+
+export const ZMatchup = z.object({
+  id: z.string(),
+  week: z.number(),
+  homeTeamId: z.string(),
+  awayTeamId: z.string(),
+  homePoints: z.number(),
+  awayPoints: z.number(),
+  homeRoster: z.array(ZRosterSpot),
+  awayRoster: z.array(ZRosterSpot),
+  winner: z.enum(["home", "away", "tie"]),
+  margin: z.number(),
+});
+
+export const ZMatchupWeek = z
+  .object({
+    platform: z.literal("sleeper"),
+    league: z.object({
+      platform: z.literal("sleeper"),
+      leagueId: z.string(),
+      season: z.number(),
+      name: z.string(),
+    }),
+    generatedAt: z.string(),
+    week: z.number(),
+    teams: z.array(
+      z.object({
+        teamId: z.string(),
+        displayName: z.string(),
+        ownerUserId: z.string(),
+      })
+    ),
+    matchups: z.array(ZMatchup),
+    summary: z.object({
+      topScorerTeamId: z.string(),
+      topScorerPoints: z.number(),
+      biggestBlowoutGameId: z.string().nullable(),
+      closestGameId: z.string().nullable(),
+    }),
+    weeklyAwards: z.array(
+      z.object({
+        key: z.string(),
+        label: z.string(),
+        teamId: z.string().optional(),
+        value: z.number().optional(),
+        meta: z.record(z.unknown()).optional(),
+      })
+    ),
+  })
+  .strict();
+
+export type SleeperUser = z.infer<typeof ZSleeperUser>;
+export type SleeperLeague = z.infer<typeof ZSleeperLeague>;
+export type SleeperMatchup = z.infer<typeof ZSleeperMatchup>;
+export type SleeperRoster = z.infer<typeof ZSleeperRoster>;
+export type SleeperUserMap = z.infer<typeof ZSleeperUserMap>;
+export type MatchupWeekSchema = z.infer<typeof ZMatchupWeek>;

--- a/package.json
+++ b/package.json
@@ -6,14 +6,17 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "tsx --test"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "@supabase/supabase-js": "^2.42.0",
-    "posthog-node": "^4.0.0"
+    "posthog-node": "^4.0.0",
+    "zod": "^3.23.8",
+    "@sentry/nextjs": "^7.119.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
@@ -24,6 +27,8 @@
     "postcss": "^8.4.38",
     "autoprefixer": "^10.4.19",
     "@tailwindcss/typography": "^0.5.10",
-    "tsx": "^3.12.7"
+    "tsx": "^3.12.7",
+    "vitest": "^1.6.1",
+    "@playwright/test": "^1.44.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
+});

--- a/tests/sleeper.contract.test.ts
+++ b/tests/sleeper.contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { toDomain } from '../lib/providers/sleeper';
+import { ZMatchupWeek } from '../lib/schemas';
+import type { LeagueMeta } from '../types/domain';
+
+describe('Sleeper contract', () => {
+  it('normalizes matchup week', () => {
+    const league: LeagueMeta = {
+      platform: 'sleeper',
+      leagueId: '1',
+      season: 2023,
+      name: 'Test League',
+    };
+    const matchups = [
+      {
+        matchup_id: 1,
+        roster_id: 1,
+        points: 100,
+        starters: ['p1'],
+        players: ['p1', 'p2'],
+        players_points: { p1: 100, p2: 0 },
+      },
+      {
+        matchup_id: 1,
+        roster_id: 2,
+        points: 90,
+        starters: ['p3'],
+        players: ['p3', 'p4'],
+        players_points: { p3: 90, p4: 0 },
+      },
+    ];
+    const rosters = [
+      { roster_id: 1, owner_id: 'u1' },
+      { roster_id: 2, owner_id: 'u2' },
+    ];
+    const users = [
+      { user_id: 'u1', username: 'alice', display_name: 'Alice' },
+      { user_id: 'u2', username: 'bob', display_name: 'Bob' },
+    ];
+
+    const domain = toDomain(league, 1, { matchups, rosters, users });
+    const parsed = ZMatchupWeek.parse(domain);
+    expect(parsed.matchups).toHaveLength(1);
+    expect(parsed.summary.topScorerTeamId).toBe('1');
+  });
+});

--- a/tests/week.resolver.test.ts
+++ b/tests/week.resolver.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLastCompletedWeek } from '../lib/providers/sleeper';
+
+describe('resolveLastCompletedWeek', () => {
+  it('handles preseason', () => {
+    expect(resolveLastCompletedWeek(2023, new Date('2023-08-20'))).toBe(0);
+  });
+
+  it('returns last completed week on Tuesday', () => {
+    expect(resolveLastCompletedWeek(2023, new Date('2023-09-19T12:00:00Z'))).toBe(1);
+  });
+
+  it('clamps to week 18 after season', () => {
+    expect(resolveLastCompletedWeek(2023, new Date('2024-02-10'))).toBe(18);
+  });
+});

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -1,0 +1,65 @@
+export type LeagueMeta = {
+  platform: "sleeper";
+  leagueId: string;
+  season: number;
+  name: string;
+};
+
+export type UserHandle = {
+  platform: "sleeper";
+  username: string;
+};
+
+export type Team = {
+  teamId: string;
+  displayName: string;
+  ownerUserId: string;
+};
+
+export type RosterSpot = {
+  slot: string;
+  playerId: string;
+  points: number;
+};
+
+export type Matchup = {
+  id: string;
+  week: number;
+  homeTeamId: string;
+  awayTeamId: string;
+  homePoints: number;
+  awayPoints: number;
+  homeRoster: RosterSpot[];
+  awayRoster: RosterSpot[];
+  winner: "home" | "away" | "tie";
+  margin: number;
+};
+
+export type MatchupWeek = {
+  platform: "sleeper";
+  league: LeagueMeta;
+  generatedAt: string;
+  week: number;
+  teams: Team[];
+  matchups: Matchup[];
+  summary: {
+    topScorerTeamId: string;
+    topScorerPoints: number;
+    biggestBlowoutGameId: string | null;
+    closestGameId: string | null;
+  };
+  weeklyAwards: Array<{
+    key: string;
+    label: string;
+    teamId?: string;
+    value?: number;
+    meta?: Record<string, unknown>;
+  }>;
+};
+
+export type EpisodeDraft = {
+  leagueId: string;
+  week: number;
+  outline: string[];
+  scriptMarkdown: string;
+};


### PR DESCRIPTION
## Summary
- add typed domain models and zod schemas
- implement Sleeper provider with safe fetch and week resolution
- build studio flow with server actions and basic snapshot card

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b622060fd8832e9af81b8e2a8e7798