### PR TITLE
feat: add metrics api and handle errors

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { track } from '@/lib/metrics';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { event, userId, properties } = await req.json();
+    if (!event) {
+      return NextResponse.json({ ok: false, error: 'missing event' }, { status: 400 });
+    }
+    track(event, userId, properties);
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
+  }
+}

--- a/app/e/[episodeId]/page.tsx
+++ b/app/e/[episodeId]/page.tsx
@@ -25,7 +25,17 @@ export default async function EpisodePage({
             controls
             className="w-full"
             src={data.audio_url}
-            onPlay={() => fetch('/api/metrics', { method: 'POST' })}
+            onPlay={() => {
+              fetch('/api/metrics', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  event: 'episode_played',
+                  userId: data.user_id,
+                  properties: { episode_id: data.id },
+                }),
+              }).catch((err) => console.error('track error', err));
+            }}
           />
         )}
         <button


### PR DESCRIPTION
## Summary
- add metrics API route that records events
- send episode play events and handle tracking failures gracefully

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b633e75710832ead6e6440e42baefe