### PR TITLE
refactor: extract Yahoo auth hook

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { useYahooAuth } from "../hooks/useYahooAuth";
+
 type League = { league_id: string; name: string; season: string };
 
 export default function Dashboard() {
@@ -37,11 +39,7 @@ export default function Dashboard() {
     }
   }, [provider]);
 
-  const handleYahoo = () => {
-    const uid = localStorage.getItem("uid") ?? crypto.randomUUID();
-    localStorage.setItem("uid", uid);
-    window.location.href = `/api/auth/yahoo?userId=${encodeURIComponent(uid)}`;
-  };
+  const handleYahoo = useYahooAuth();
 
   return (
     <main className="min-h-screen px-6 py-16">

--- a/app/hooks/useYahooAuth.ts
+++ b/app/hooks/useYahooAuth.ts
@@ -1,0 +1,11 @@
+"use client";
+
+export function useYahooAuth() {
+  return () => {
+    const uid = localStorage.getItem("uid") ?? crypto.randomUUID();
+    localStorage.setItem("uid", uid);
+    const url = `/api/auth/yahoo?userId=${encodeURIComponent(uid)}`;
+    window.location.href = url;
+    return { uid, url };
+  };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
+import { useYahooAuth } from "./hooks/useYahooAuth";
+
 export default function Home() {
-  const handleYahoo = () => {
-    const uid = localStorage.getItem("uid") ?? crypto.randomUUID();
-    localStorage.setItem("uid", uid);
-    window.location.href = `/api/auth/yahoo?userId=${encodeURIComponent(uid)}`;
-  };
+  const handleYahoo = useYahooAuth();
 
   return (
     <main className="min-h-screen flex flex-col">

--- a/tests/useYahooAuth.test.ts
+++ b/tests/useYahooAuth.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useYahooAuth } from '../app/hooks/useYahooAuth';
+
+describe('useYahooAuth', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+  });
+
+  it('returns stable UID and redirect URL', () => {
+    const start = useYahooAuth();
+    const first = start();
+    expect(first.url).toBe(`/api/auth/yahoo?userId=${encodeURIComponent(first.uid)}`);
+    expect(localStorage.getItem('uid')).toBe(first.uid);
+    expect(window.location.href).toBe(first.url);
+
+    const second = start();
+    expect(second.uid).toBe(first.uid);
+    expect(second.url).toBe(first.url);
+    expect(window.location.href).toBe(second.url);
+  });
+});


### PR DESCRIPTION
## Summary
- extract Yahoo OAuth UID and redirect logic into `useYahooAuth` hook
- reuse hook in home and dashboard pages
- add unit test for stable UID and redirect URL

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: package installation forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b633eabb74832ebe5ce5b196c6c65e