### PR TITLE
Add timeout-enabled AbortController to safeFetch with tests

### DIFF
--- a/lib/http/safeFetch.ts
+++ b/lib/http/safeFetch.ts
@@ -1,18 +1,52 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 
+/** Optional request init parameters supported by {@link safeFetch}. */
+interface SafeFetchInit extends RequestInit {
+  /**
+   * Maximum time in milliseconds to wait for the request before aborting.
+   * Defaults to 10 seconds.
+   */
+  timeoutMs?: number;
+}
+
 export class FetchError extends Error {
   constructor(public code: string, message: string, public status: number) {
     super(message);
   }
 }
 
-export async function safeFetch<T>(url: string, init: RequestInit = {}): Promise<T> {
+export async function safeFetch<T>(
+  url: string,
+  init: SafeFetchInit = {},
+): Promise<T> {
   const maxAttempts = 3;
   let attempt = 0;
-  const requestId = (init.headers as any)?.['x-request-id'] || crypto.randomUUID();
-  const headers = { ...(init.headers || {}), 'x-request-id': requestId } as Record<string, string>;
+  const { timeoutMs = 10_000, ...requestInit } = init;
+  const requestId = (requestInit.headers as any)?.['x-request-id'] || crypto.randomUUID();
+  const headers = {
+    ...(requestInit.headers || {}),
+    'x-request-id': requestId,
+  } as Record<string, string>;
+
   while (attempt < maxAttempts) {
-    const res = await fetch(url, { ...init, headers });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        ...requestInit,
+        headers,
+        signal: controller.signal,
+      });
+    } catch (err: any) {
+      clearTimeout(timeoutId);
+      if (err?.name === 'AbortError') {
+        throw new FetchError('timeout', 'Request timed out', 408);
+      }
+      throw err;
+    }
+    clearTimeout(timeoutId);
+
     if (res.status === 429 || res.status >= 500) {
       attempt++;
       const delay = Math.pow(2, attempt) * 100 + Math.random() * 100;

--- a/tests/safeFetch.test.ts
+++ b/tests/safeFetch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { safeFetch, FetchError } from '../lib/http/safeFetch';
+
+describe('safeFetch', () => {
+  it('resolves json when successful', async () => {
+    const data = { ok: true };
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch' as any)
+      .mockImplementation(async (_url: any, init: any) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return new Response(JSON.stringify(data), { status: 200 });
+      });
+
+    const res = await safeFetch<typeof data>('https://example.com');
+    expect(res).toEqual(data);
+    fetchSpy.mockRestore();
+  });
+
+  it('aborts when timeout elapses', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch' as any)
+      .mockImplementation((_url: any, init: any) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        });
+      });
+
+    const promise = safeFetch('https://example.com', { timeoutMs: 1000 });
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).rejects.toBeInstanceOf(FetchError);
+    await expect(promise).rejects.toMatchObject({ code: 'timeout' });
+
+    fetchSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable timeout and AbortController to safeFetch
- supply controller signal to fetch and raise timeout error
- add unit tests covering successful fetch and timeout

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b633eb8db4832e8ec6152cfd2b9d04