### PR TITLE
refactor: camelCase type properties and snapshot adapter

### DIFF
--- a/app/api/episode/generate/route.ts
+++ b/app/api/episode/generate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/db';
 import { computeFacts } from '@/lib/analysis/compute';
 import { buildScript } from '@/lib/analysis/script';
+import { adaptSnapshot } from '@/lib/migrate';
 import { track } from '@/lib/metrics';
 
 export async function POST(req: NextRequest) {
@@ -33,7 +34,8 @@ export async function POST(req: NextRequest) {
     if (snapErr || !snap) {
       return NextResponse.json({ ok: false, error: 'snapshot_missing' }, { status: 400 });
     }
-    const facts = computeFacts(snap.raw_json);
+    const snapshot = adaptSnapshot(snap.raw_json);
+    const facts = computeFacts(snapshot);
     const script = buildScript({ facts, expert_headlines: [] });
     const { data: ep, error: epErr } = await supabaseAdmin
       .from('episode')

--- a/app/api/leagues/list/route.ts
+++ b/app/api/leagues/list/route.ts
@@ -9,7 +9,7 @@ import { listLeagues as yahooListLeagues } from '../../../../lib/providers/yahoo
 export const runtime = 'nodejs';       // <— ensure Node, not Edge
 export const dynamic = 'force-dynamic';
 
-type League = { league_id: string; name: string; season: string };
+type League = { leagueId: string; name: string; season: string };
 
 function fail(stage: string, detail?: unknown, status = 500) {
   if (detail) console.error(`[leagues:list] ${stage}`, detail);

--- a/app/api/snapshot/fetch/route.ts
+++ b/app/api/snapshot/fetch/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
     await upsertSnapshot(provider, leagueId, fetchWeek, snapshot);
     track('snapshot_saved', userId, {
       provider,
-      league_id: leagueId,
+      leagueId: leagueId,
       week: fetchWeek,
     });
     return NextResponse.json({ ok: true, week: fetchWeek });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-type League = { league_id: string; name: string; season: string };
+type League = { leagueId: string; name: string; season: string };
 
 export default function Dashboard() {
   const [provider, setProvider] = useState<string | null>(null);
@@ -84,7 +84,7 @@ export default function Dashboard() {
                   Select a league…
                 </option>
                 {leagues.map((l) => (
-                  <option key={l.league_id} value={l.league_id}>
+                  <option key={l.leagueId} value={l.leagueId}>
                     {l.name} {l.season ? `(${l.season})` : ""}
                   </option>
                 ))}

--- a/lib/analysis/__tests__/compute.test.ts
+++ b/lib/analysis/__tests__/compute.test.ts
@@ -5,14 +5,14 @@ import { Snapshot } from '../../types';
 
 const snapshot: Snapshot = {
   week: 1,
-  league_name: 'Test League',
+  leagueName: 'Test League',
   teams: [
     {
-      team_id: '1',
-      manager_name: 'Alice',
-      team_name: 'Aces',
-      points_for_week: 120,
-      points_season: 300,
+      teamId: '1',
+      managerName: 'Alice',
+      teamName: 'Aces',
+      pointsForWeek: 120,
+      pointsSeason: 300,
       starters: [
         { id: 's1', name: 'StarterA', points: 20 },
         { id: 'w1', name: 'WaiverStar', points: 25, acquisitionType: 'waiver' },
@@ -21,11 +21,11 @@ const snapshot: Snapshot = {
       bench: [{ id: 'b1', name: 'BenchGuy', points: 30 }],
     },
     {
-      team_id: '2',
-      manager_name: 'Bob',
-      team_name: 'Blitz',
-      points_for_week: 110,
-      points_season: 330,
+      teamId: '2',
+      managerName: 'Bob',
+      teamName: 'Blitz',
+      pointsForWeek: 110,
+      pointsSeason: 330,
       starters: [
         { id: 'sb1', name: 'SlowStart', points: 5 },
         { id: 'sb2', name: 'OKStart', points: 15 },
@@ -33,32 +33,32 @@ const snapshot: Snapshot = {
       bench: [{ id: 'bb1', name: 'BenchBoom', points: 25 }],
     },
     {
-      team_id: '3',
-      manager_name: 'Carl',
-      team_name: 'Crushers',
-      points_for_week: 90,
-      points_season: 310,
+      teamId: '3',
+      managerName: 'Carl',
+      teamName: 'Crushers',
+      pointsForWeek: 90,
+      pointsSeason: 310,
       starters: [{ id: 'c1', name: 'C1', points: 40 }],
       bench: [{ id: 'cb1', name: 'CB1', points: 5 }],
     },
     {
-      team_id: '4',
-      manager_name: 'Dana',
-      team_name: 'Dynamos',
-      points_for_week: 91,
-      points_season: 305,
+      teamId: '4',
+      managerName: 'Dana',
+      teamName: 'Dynamos',
+      pointsForWeek: 91,
+      pointsSeason: 305,
       starters: [{ id: 'd1', name: 'D1', points: 42 }],
       bench: [{ id: 'db1', name: 'DB1', points: 10 }],
     },
   ],
   matchups: [
-    { home: '1', away: '2', home_score: 120, away_score: 110 },
-    { home: '3', away: '4', home_score: 90, away_score: 91 },
+    { home: '1', away: '2', homeScore: 120, awayScore: 110 },
+    { home: '3', away: '4', homeScore: 90, awayScore: 91 },
   ],
   transactions: {
     waivers: [
       {
-        team_id: '1',
+        teamId: '1',
         player: { id: 'w1', name: 'WaiverStar', points: 25, acquisitionType: 'waiver' },
         started: true,
       },
@@ -70,8 +70,8 @@ const snapshot: Snapshot = {
 
 test('computeFacts basics', () => {
   const facts = computeFacts(snapshot);
-  assert.equal(facts.upset?.winner.team_id, '1');
-  assert.equal(facts.narrow_loss?.loser.team_id, '3');
-  assert.equal(facts.bench_blunder?.team.team_id, '2');
-  assert.equal(facts.waiver_roi?.team.team_id, '1');
+  assert.equal(facts.upset?.winner.teamId, '1');
+  assert.equal(facts.narrowLoss?.loser.teamId, '3');
+  assert.equal(facts.benchBlunder?.team.teamId, '2');
+  assert.equal(facts.waiverRoi?.team.teamId, '1');
 });

--- a/lib/analysis/compute.ts
+++ b/lib/analysis/compute.ts
@@ -2,7 +2,7 @@ import { Snapshot, Facts, Team, Player } from '../types';
 
 const toMap = (teams: Team[]) => {
   const map: Record<string, Team> = {};
-  teams.forEach((t) => (map[t.team_id] = t));
+  teams.forEach((t) => (map[t.teamId] = t));
   return map;
 };
 
@@ -10,30 +10,30 @@ export function computeFacts(snapshot: Snapshot): Facts {
   const teamMap = toMap(snapshot.teams);
 
   const topTeam = [...snapshot.teams].sort((a, b) => {
-    if (b.points_for_week !== a.points_for_week) {
-      return b.points_for_week - a.points_for_week;
+    if (b.pointsForWeek !== a.pointsForWeek) {
+      return b.pointsForWeek - a.pointsForWeek;
     }
-    return a.team_id.localeCompare(b.team_id);
+    return a.teamId.localeCompare(b.teamId);
   })[0];
 
   let upset: Facts['upset'];
-  let narrow_loss: Facts['narrow_loss'];
+  let narrowLoss: Facts['narrowLoss'];
   snapshot.matchups.forEach((m) => {
     const home = teamMap[m.home];
     const away = teamMap[m.away];
-    const winner = m.home_score >= m.away_score ? home : away;
+    const winner = m.homeScore >= m.awayScore ? home : away;
     const loser = winner === home ? away : home;
-    const margin = Math.abs(m.home_score - m.away_score);
+    const margin = Math.abs(m.homeScore - m.awayScore);
 
-    if (!upset && winner.points_season < loser.points_season) {
+    if (!upset && winner.pointsSeason < loser.pointsSeason) {
       upset = { winner, loser, margin };
     }
-    if (margin < 10 && (!narrow_loss || margin < narrow_loss.margin)) {
-      narrow_loss = { winner, loser, margin };
+    if (margin < 10 && (!narrowLoss || margin < narrowLoss.margin)) {
+      narrowLoss = { winner, loser, margin };
     }
   });
 
-  let bench_blunder: Facts['bench_blunder'];
+  let benchBlunder: Facts['benchBlunder'];
   snapshot.teams.forEach((team) => {
     if (!team.starters || !team.bench || team.starters.length === 0 || team.bench.length === 0) return;
     const worstStarter = team.starters.reduce((min, p) =>
@@ -43,31 +43,31 @@ export function computeFacts(snapshot: Snapshot): Facts {
       p.points > max.points ? p : max
     );
     const delta = bestBench.points - worstStarter.points;
-    if (delta > 0 && (!bench_blunder || delta > bench_blunder.delta)) {
-      bench_blunder = { team, starter: worstStarter, bench: bestBench, delta };
+    if (delta > 0 && (!benchBlunder || delta > benchBlunder.delta)) {
+      benchBlunder = { team, starter: worstStarter, bench: bestBench, delta };
     }
   });
 
-  let waiver_roi: Facts['waiver_roi'];
+  let waiverRoi: Facts['waiverRoi'];
   snapshot.teams.forEach((team) => {
     const waiverPoints = (team.starters || [])
       .filter((p) => p.acquisitionType === 'waiver')
       .reduce((sum, p) => sum + p.points, 0);
-    if (waiverPoints > 0 && (!waiver_roi || waiverPoints > waiver_roi.points)) {
-      waiver_roi = { team, points: waiverPoints };
+    if (waiverPoints > 0 && (!waiverRoi || waiverPoints > waiverRoi.points)) {
+      waiverRoi = { team, points: waiverPoints };
     }
   });
 
   return {
     week: snapshot.week,
-    league_name: snapshot.league_name,
+    leagueName: snapshot.leagueName,
     teams: snapshot.teams,
-    top_scorer: { team: topTeam },
+    topScorer: { team: topTeam },
     upset,
-    narrow_loss,
-    bench_blunder,
-    waiver_roi,
-    trade_impact: undefined,
+    narrowLoss,
+    benchBlunder,
+    waiverRoi,
+    tradeImpact: undefined,
     injuries: snapshot.transactions.injuries,
     rivalries: [],
   };

--- a/lib/analysis/script.ts
+++ b/lib/analysis/script.ts
@@ -8,29 +8,29 @@ export function buildScript({
   expert_headlines: string[];
 }): string {
   const lines: string[] = [];
-  lines.push(`# Week ${facts.week} Recap — ${facts.league_name}`);
+  lines.push(`# Week ${facts.week} Recap — ${facts.leagueName}`);
   lines.push(
-    `${facts.top_scorer.team.manager_name}'s ${facts.top_scorer.team.team_name} slapped ${facts.top_scorer.team.points_for_week} on the board.`
+    `${facts.topScorer.team.managerName}'s ${facts.topScorer.team.teamName} slapped ${facts.topScorer.team.pointsForWeek} on the board.`
   );
 
   if (facts.upset) {
     lines.push(
-      `Upset special: ${facts.upset.winner.team_name} shocked ${facts.upset.loser.team_name} by ${facts.upset.margin}.`
+      `Upset special: ${facts.upset.winner.teamName} shocked ${facts.upset.loser.teamName} by ${facts.upset.margin}.`
     );
   }
-  if (facts.narrow_loss) {
+  if (facts.narrowLoss) {
     lines.push(
-      `Nail-biter: ${facts.narrow_loss.loser.team_name} lost by ${facts.narrow_loss.margin}.`
+      `Nail-biter: ${facts.narrowLoss.loser.teamName} lost by ${facts.narrowLoss.margin}.`
     );
   }
-  if (facts.bench_blunder) {
+  if (facts.benchBlunder) {
     lines.push(
-      `Bench blunder: ${facts.bench_blunder.team.manager_name} sat ${facts.bench_blunder.bench.name} (${facts.bench_blunder.bench.points}).`
+      `Bench blunder: ${facts.benchBlunder.team.managerName} sat ${facts.benchBlunder.bench.name} (${facts.benchBlunder.bench.points}).`
     );
   }
-  if (facts.waiver_roi) {
+  if (facts.waiverRoi) {
     lines.push(
-      `Waiver win: ${facts.waiver_roi.team.manager_name} got ${facts.waiver_roi.points} from pickups.`
+      `Waiver win: ${facts.waiverRoi.team.managerName} got ${facts.waiverRoi.points} from pickups.`
     );
   }
   facts.injuries.forEach((i) =>

--- a/lib/migrate.ts
+++ b/lib/migrate.ts
@@ -1,0 +1,40 @@
+import { Snapshot } from './types';
+
+// Adapt legacy snake_case snapshots to the new camelCase structure.
+export function adaptSnapshot(data: any): Snapshot {
+  if (!data || typeof data !== 'object') {
+    throw new Error('invalid snapshot');
+  }
+  // If data already uses camelCase, assume it's correct.
+  if ('leagueName' in data) {
+    return data as Snapshot;
+  }
+  return {
+    week: data.week,
+    leagueName: data.league_name,
+    teams: (data.teams || []).map((t: any) => ({
+      teamId: t.team_id,
+      managerName: t.manager_name,
+      teamName: t.team_name,
+      pointsForWeek: t.points_for_week,
+      pointsSeason: t.points_season,
+      starters: t.starters,
+      bench: t.bench,
+    })),
+    matchups: (data.matchups || []).map((m: any) => ({
+      home: m.home,
+      away: m.away,
+      homeScore: m.home_score,
+      awayScore: m.away_score,
+    })),
+    transactions: {
+      waivers: (data.transactions?.waivers || []).map((w: any) => ({
+        teamId: w.team_id,
+        player: w.player,
+        started: w.started,
+      })),
+      trades: data.transactions?.trades || [],
+      injuries: data.transactions?.injuries || [],
+    },
+  };
+}

--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -11,7 +11,7 @@ export interface YahooTokenResponse {
   [key: string]: any;
 }
 
-export type League = { league_id: string; name: string; season: string };
+export type League = { leagueId: string; name: string; season: string };
 
 /** Exchange an authorization code for tokens. */
 export async function oauthExchange(code: string): Promise<YahooTokenResponse> {
@@ -116,7 +116,7 @@ export async function listLeagues(accessToken: string): Promise<League[]> {
 
       if (league_key && name) {
         leagues.push({
-          league_id: String(league_key),
+          leagueId: String(league_key),
           name: String(name),
           season: season != null ? String(season) : "",
         });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 export type Provider = 'sleeper' | 'yahoo';
 
 export interface League {
-  league_id: string;
+  leagueId: string;
   name: string;
   season: string | number;
 }
@@ -14,11 +14,11 @@ export interface Player {
 }
 
 export interface Team {
-  team_id: string;
-  manager_name: string;
-  team_name: string;
-  points_for_week: number;
-  points_season: number;
+  teamId: string;
+  managerName: string;
+  teamName: string;
+  pointsForWeek: number;
+  pointsSeason: number;
   starters?: Player[];
   bench?: Player[];
 }
@@ -26,8 +26,8 @@ export interface Team {
 export interface Matchup {
   home: string;
   away: string;
-  home_score: number;
-  away_score: number;
+  homeScore: number;
+  awayScore: number;
 }
 
 export interface Injury {
@@ -38,11 +38,11 @@ export interface Injury {
 
 export interface Snapshot {
   week: number;
-  league_name: string;
+  leagueName: string;
   teams: Team[];
   matchups: Matchup[];
   transactions: {
-    waivers: { team_id: string; player: Player; started: boolean }[];
+    waivers: { teamId: string; player: Player; started: boolean }[];
     trades: any[]; // TODO refine
     injuries: Injury[];
   };
@@ -50,14 +50,14 @@ export interface Snapshot {
 
 export interface Facts {
   week: number;
-  league_name: string;
+  leagueName: string;
   teams: Team[];
-  top_scorer: { team: Team };
+  topScorer: { team: Team };
   upset?: { winner: Team; loser: Team; margin: number };
-  narrow_loss?: { winner: Team; loser: Team; margin: number };
-  bench_blunder?: { team: Team; starter: Player; bench: Player; delta: number };
-  waiver_roi?: { team: Team; points: number };
-  trade_impact?: any; // TODO refine
+  narrowLoss?: { winner: Team; loser: Team; margin: number };
+  benchBlunder?: { team: Team; starter: Player; bench: Player; delta: number };
+  waiverRoi?: { team: Team; points: number };
+  tradeImpact?: any; // TODO refine
   injuries: Injury[];
-  rivalries: { teamA: string; teamB: string; history_summary: string }[];
+  rivalries: { teamA: string; teamB: string; historySummary: string }[];
 }


### PR DESCRIPTION
## Summary
- refactor league, team, matchup, snapshot, and facts interfaces to camelCase
- update analysis, APIs, and tests for camelCase fields
- add adapter to migrate legacy snake_case snapshots

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_b_68b633efc16c832e8a7a3d18c4b615b1