### PR TITLE
feat: flush PostHog metrics

### DIFF
--- a/app/api/episode/generate/route.ts
+++ b/app/api/episode/generate/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/db';
 import { computeFacts } from '@/lib/analysis/compute';
 import { buildScript } from '@/lib/analysis/script';
-import { track } from '@/lib/metrics';
+import { track, flush } from '@/lib/metrics';
 
 export async function POST(req: NextRequest) {
   try {
@@ -50,6 +50,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 });
     }
     track('episode_generated', userId, { episode_id: ep.id });
+    await flush();
     return NextResponse.json({ ok: true, episodeId: ep.id });
   } catch (err: any) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });

--- a/app/api/episode/render/route.ts
+++ b/app/api/episode/render/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/db';
-import { track } from '@/lib/metrics';
+import { track, flush } from '@/lib/metrics';
 
 export async function POST(req: NextRequest) {
   try {
@@ -27,6 +27,7 @@ export async function POST(req: NextRequest) {
       .eq('id', episodeId);
 
     track('episode_rendered', userId, { episode_id: episodeId, duration_s: duration });
+    await flush();
     return NextResponse.json({ ok: true, audio_url: fakeUrl });
   } catch (err: any) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });

--- a/app/api/snapshot/fetch/route.ts
+++ b/app/api/snapshot/fetch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { decryptToken } from '@/lib/security';
 import { getSupabaseAdmin, upsertSnapshot } from '@/lib/db';
-import { track } from '@/lib/metrics';
+import { track, flush } from '@/lib/metrics';
 import { getLeagueWeek as sleeperData } from '@/lib/providers/sleeper';
 import { getLeagueWeekData as yahooData } from '@/lib/providers/yahoo';
 import { Provider } from '@/lib/types';
@@ -42,6 +42,7 @@ export async function POST(req: NextRequest) {
       league_id: leagueId,
       week: fetchWeek,
     });
+    await flush();
     return NextResponse.json({ ok: true, week: fetchWeek });
   } catch (err: any) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });

--- a/lib/__tests__/metrics.test.ts
+++ b/lib/__tests__/metrics.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PostHog } from 'posthog-node';
+
+test('flush drains queued events', async () => {
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test';
+  const { track, flush } = await import('../metrics');
+
+  const events: any[] = [];
+  PostHog.prototype.capture = function (event: any) {
+    events.push(event);
+  };
+  PostHog.prototype.flush = async function () {
+    events.length = 0;
+  };
+
+  track('example', undefined);
+  assert.equal(events.length, 1);
+
+  await flush();
+  assert.equal(events.length, 0);
+});

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -13,3 +13,21 @@ export const track = (
   if (!client) return;
   client.capture({ event, distinctId: distinctId || 'anon', properties });
 };
+
+export const flush = async () => {
+  if (!client) return;
+  await client.flush();
+};
+
+if (client) {
+  const handleExit = async () => {
+    try {
+      await flush();
+    } catch {
+      // ignore flush errors during shutdown
+    }
+  };
+  ['beforeExit', 'SIGINT', 'SIGTERM'].forEach((evt) =>
+    process.once(evt as any, handleExit)
+  );
+}


### PR DESCRIPTION
## Summary
- add flush helper for PostHog metrics and hook into process shutdown
- flush metrics after long-running API jobs
- test flushing queued events

## Testing
- `npm test` *(fails: vitest not found)*
- `node --import tsx --test lib/__tests__/metrics.test.ts`
- `node --import tsx --test lib/analysis/__tests__/compute.test.ts` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_b_68b633f6c3dc832e97db1ddbc0423a76