### PR TITLE
Require KMS_KEY env variable and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Minimal Next.js 14 + Tailwind starter with:
 - `/api/auth/*/callback` posts `{ provider, code }` to Make.com webhook
 
 ## Env vars (Vercel → Project → Settings → Environment Variables)
+- `KMS_KEY` — **required in all environments**; 32+ character key for encrypting tokens
 - `SLEEPER_CLIENT_ID` / `SLEEPER_CLIENT_SECRET`
 - `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper/callback`
 - `YAHOO_CLIENT_ID` / `YAHOO_CLIENT_SECRET`

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,10 +1,11 @@
 import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 
 const ALGO = 'aes-256-gcm';
-const KEY = Buffer.from(
-  (process.env.KMS_KEY || 'dev_key_dev_key_dev_key_dev_key').slice(0, 32),
-  'utf8'
-);
+const kmsKey = process.env.KMS_KEY;
+if (!kmsKey) {
+  throw new Error('KMS_KEY environment variable is required');
+}
+const KEY = Buffer.from(kmsKey.slice(0, 32), 'utf8');
 
 export async function encryptToken(plain: string): Promise<string> {
   const iv = randomBytes(12);


### PR DESCRIPTION
## Summary
- ensure encryption uses provided KMS_KEY and fails fast if missing
- document mandatory KMS_KEY environment variable

## Testing
- `KMS_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b633f7deac832eb3de2641d11d7b95