### PR TITLE
feat: track loading while fetching leagues and generating episodes

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,14 +2,51 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useYahooAuth } from "../hooks/useYahooAuth";
 
 type League = { leagueId: string; name: string; season: string };
 
+function Spinner({ label }: { label: string }) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className="flex items-center justify-center"
+    >
+      <svg
+        className="animate-spin h-5 w-5 text-gray-500"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+          fill="none"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
 export default function Dashboard() {
+  const router = useRouter();
   const [provider, setProvider] = useState<string | null>(null);
   const [leagues, setLeagues] = useState<League[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loadingLeagues, setLoadingLeagues] = useState(false);
+  const [loadingEpisode, setLoadingEpisode] = useState(false);
+  const [selectedLeague, setSelectedLeague] = useState("");
+  const [status, setStatus] = useState("");
 
   useEffect(() => {
     const search = new URLSearchParams(window.location.search);
@@ -20,6 +57,8 @@ export default function Dashboard() {
     if (provider === "yahoo") {
       setError(null);
       setLeagues([]);
+      setLoadingLeagues(true);
+      setStatus("Loading leagues...");
 
       fetch("/api/leagues/list?provider=yahoo", { cache: "no-store" })
         .then((r) => r.json())
@@ -46,15 +85,63 @@ export default function Dashboard() {
           } else {
             setError("internal_error:unknown");
           }
+        })
+        .finally(() => {
+          setLoadingLeagues(false);
+          setStatus("");
         });
     }
   }, [provider]);
 
   const handleYahoo = useYahooAuth();
 
+  async function onGenerate() {
+    if (!selectedLeague) return;
+    setLoadingEpisode(true);
+    setStatus("Generating episode...");
+    try {
+      const snapshotRes = await fetch("/api/snapshot/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "yahoo", leagueId: selectedLeague, week: undefined }),
+      });
+      const { week } = await snapshotRes.json();
+
+      const episodeRes = await fetch("/api/episode/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "yahoo", leagueId: selectedLeague, week }),
+      });
+      const { episodeId } = await episodeRes.json();
+
+      await fetch("/api/episode/render", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ episodeId }),
+      });
+
+      router.push(`/e/${episodeId}`);
+    } catch (e: any) {
+      if (typeof e?.message === "string") {
+        setError(e.message);
+      } else {
+        setError("internal_error:unknown");
+      }
+    } finally {
+      setLoadingEpisode(false);
+      setStatus("");
+    }
+  }
+
   return (
     <main className="min-h-screen px-6 py-16">
-      <div className="container space-y-6">
+      <div
+        className="container space-y-6"
+        aria-busy={loadingLeagues || loadingEpisode}
+      >
+        <div aria-live="polite" className="sr-only">
+          {status}
+        </div>
         <h1 className="text-3xl font-extrabold">Dashboard</h1>
 
         {provider ? (
@@ -83,24 +170,45 @@ export default function Dashboard() {
 
             {error && <p className="text-red-600">Error: {error}</p>}
 
-            {!error && leagues.length === 0 && (
+            {!error && loadingLeagues && <Spinner label="Loading leagues" />}
+
+            {!error && !loadingLeagues && leagues.length === 0 && (
               <p className="text-gray-600">No leagues found.</p>
             )}
 
-            {leagues.length > 0 && (
-              <select
-                className="rounded-xl px-5 py-3 border w-full"
-                defaultValue=""
-              >
-                <option value="" disabled>
-                  Select a league…
-                </option>
-                {leagues.map((l) => (
-                  <option key={l.leagueId} value={l.leagueId}>
-                    {l.name} {l.season ? `(${l.season})` : ""}
+            {!loadingLeagues && leagues.length > 0 && (
+              <>
+                <select
+                  className="rounded-xl px-5 py-3 border w-full"
+                  value={selectedLeague}
+                  onChange={(e) => setSelectedLeague(e.target.value)}
+                  disabled={loadingEpisode}
+                >
+                  <option value="" disabled>
+                    Select a league…
                   </option>
-                ))}
-              </select>
+                  {leagues.map((l) => (
+                    <option key={l.leagueId} value={l.leagueId}>
+                      {l.name} {l.season ? `(${l.season})` : ""}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={onGenerate}
+                  className="btn w-full"
+                  disabled={!selectedLeague || loadingEpisode}
+                  aria-busy={loadingEpisode}
+                >
+                  {loadingEpisode ? (
+                    <div className="flex items-center justify-center gap-2">
+                      <Spinner label="Generating episode" />
+                      <span>Generating…</span>
+                    </div>
+                  ) : (
+                    "Generate Episode"
+                  )}
+                </button>
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- track league fetching and episode generation status on dashboard
- show spinner and disable controls during async operations
- announce loading states for screen readers

## Testing
- `npm test` *(fails: Module 'vitest' has no exported member 'vi')*


------
https://chatgpt.com/codex/tasks/task_b_68b6399e3bc0832eb2b8e614234e3963