### PR TITLE
Handle Yahoo OAuth errors with query param alerts

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,10 +10,32 @@ export default function Dashboard() {
   const [provider, setProvider] = useState<string | null>(null);
   const [leagues, setLeagues] = useState<League[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  function mapAuthError(code: string) {
+    switch (code) {
+      case "oauth_exchange":
+        return "Yahoo authentication failed. Please try again.";
+      case "db_upsert":
+        return "Could not save Yahoo connection. Please try again.";
+      case "no_uid":
+        return "Missing user session. Please try again.";
+      default:
+        return "Unexpected error. Please try again.";
+    }
+  }
 
   useEffect(() => {
     const search = new URLSearchParams(window.location.search);
     setProvider(search.get("provider"));
+    const err = search.get("error");
+    if (err) {
+      const msg = err
+        .split(",")
+        .map((c) => mapAuthError(c))
+        .join(" ");
+      setAuthError(msg);
+    }
   }, []);
 
   useEffect(() => {
@@ -56,6 +78,7 @@ export default function Dashboard() {
     <main className="min-h-screen px-6 py-16">
       <div className="container space-y-6">
         <h1 className="text-3xl font-extrabold">Dashboard</h1>
+        {authError && <p className="text-red-600">{authError}</p>}
 
         {provider ? (
           <p>Provider connected: {provider}</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useYahooAuth } from "./hooks/useYahooAuth";
+
+function mapAuthError(code: string) {
+  switch (code) {
+    case "oauth_exchange":
+      return "Yahoo authentication failed. Please try again.";
+    case "db_upsert":
+      return "Could not save Yahoo connection. Please try again.";
+    case "no_uid":
+      return "Missing user session. Please try again.";
+    default:
+      return "Unexpected error. Please try again.";
+  }
+}
 
 export default function Home() {
   const handleYahoo = useYahooAuth();
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    const err = search.get("error");
+    if (err) {
+      const msg = err
+        .split(",")
+        .map((c) => mapAuthError(c))
+        .join(" ");
+      setAuthError(msg);
+    }
+  }, []);
 
   return (
     <main className="min-h-screen flex flex-col">
+      {authError && (
+        <p className="bg-red-50 text-red-600 text-center py-2">{authError}</p>
+      )}
       {/* Hero */}
       <section className="flex-1 flex items-center justify-center px-6 py-16 text-center">
         <div className="container space-y-6">


### PR DESCRIPTION
## Summary
- propagate Yahoo OAuth failures through `error` query param in callback
- show user-friendly auth errors on dashboard page
- surface auth errors on landing page

## Testing
- `npm test` *(fails: Module '"vitest"' has no exported member 'vi')*


------
https://chatgpt.com/codex/tasks/task_b_68b639a19398832e8c29e81d26e27c6d