### PR TITLE
feat: synthesize episodes with Play.ht

### DIFF
--- a/app/api/episode/render/route.ts
+++ b/app/api/episode/render/route.ts
@@ -18,17 +18,68 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: 'episode_not_found' }, { status: 404 });
     }
 
-    // TODO: Call Play.ht and store MP3 in Supabase Storage
-    const fakeUrl = `https://example.com/episodes/${episodeId}.mp3`;
-    const duration = 90;
+    // Synthesize the episode using Play.ht
+    const apiKey = process.env.PLAYHT_API_KEY;
+    const playUser = process.env.PLAYHT_USER_ID;
+    if (!apiKey || !playUser) {
+      throw new Error('Missing Play.ht credentials');
+    }
+
+    const ttsResp = await fetch('https://play.ht/api/v2/tts', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'X-User-Id': playUser,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        text: ep.script_md,
+        voice: 'en-US-1',
+        format: 'mp3',
+      }),
+    });
+    if (!ttsResp.ok) {
+      throw new Error('playht_request_failed');
+    }
+    const { id } = await ttsResp.json();
+
+    let audioUrl: string | null = null;
+    let duration = 0;
+    for (let i = 0; i < 20; i++) {
+      const statusResp = await fetch(`https://play.ht/api/v2/tts/${id}`, {
+        headers: { Authorization: `Bearer ${apiKey}`, 'X-User-Id': playUser },
+      });
+      const statusJson = await statusResp.json();
+      if (statusJson.status === 'completed') {
+        audioUrl = statusJson.audio_url || statusJson.audioUrl;
+        duration = statusJson.duration || statusJson.audio_duration || 0;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+    if (!audioUrl) {
+      throw new Error('playht_timeout');
+    }
+
+    const audioRes = await fetch(audioUrl);
+    const buffer = Buffer.from(await audioRes.arrayBuffer());
+    const path = `episodes/${episodeId}.mp3`;
+    const { error: uploadError } = await supabaseAdmin.storage
+      .from('episodes')
+      .upload(path, buffer, { upsert: true, contentType: 'audio/mpeg' });
+    if (uploadError) throw uploadError;
+
+    const { data: pub } = supabaseAdmin.storage.from('episodes').getPublicUrl(path);
+    const publicUrl = pub.publicUrl;
+
     await supabaseAdmin
       .from('episode')
-      .update({ audio_url: fakeUrl, duration_s: duration, status: 'rendered' })
+      .update({ audio_url: publicUrl, duration_s: duration, status: 'rendered' })
       .eq('id', episodeId);
 
     track('episode_rendered', userId, { episode_id: episodeId, duration_s: duration });
     await flush();
-    return NextResponse.json({ ok: true, audio_url: fakeUrl });
+    return NextResponse.json({ ok: true, audio_url: publicUrl });
   } catch (err: any) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- integrate Play.ht TTS to render episode scripts
- store synthesized audio in Supabase Storage and persist URL and duration
- track `episode_rendered` metrics and expose audio URL in API response

## Testing
- `npm test` *(fails: Module '"vitest"' has no exported member 'vi')*

------
https://chatgpt.com/codex/tasks/task_b_68b639a3e278832ea2a04ebd2646db70