### PR TITLE
feat: support Yahoo domain snapshots

### DIFF
--- a/lib/providers/__tests__/yahoo.compute.test.ts
+++ b/lib/providers/__tests__/yahoo.compute.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toSnapshot } from '../yahoo';
+import { computeFacts } from '../../analysis/compute';
+
+const rawScoreboard = {
+  fantasy_content: {
+    league: [
+      { name: 'Test League', season: '2024' },
+      {
+        scoreboard: {
+          matchups: [
+            {
+              matchup: {
+                teams: [
+                  {
+                    team: {
+                      team_id: '1',
+                      name: 'Aces',
+                      managers: [{ manager: { nickname: 'Alice', guid: '1' } }],
+                      team_points: { total: '120' },
+                      roster: {
+                        players: [
+                          { player: { player_id: 's1', name: { full: 'StarterA' }, selected_position: 'QB', total_points: '20' } },
+                          { player: { player_id: 'w1', name: { full: 'WaiverStar' }, selected_position: 'RB', total_points: '25', acquisition_type: 'waiver' } },
+                          { player: { player_id: 's2', name: { full: 'StarterB' }, selected_position: 'WR', total_points: '10' } },
+                          { player: { player_id: 'b1', name: { full: 'BenchGuy' }, selected_position: 'BN', total_points: '15' } },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    team: {
+                      team_id: '2',
+                      name: 'Blitz',
+                      managers: [{ manager: { nickname: 'Bob', guid: '2' } }],
+                      team_points: { total: '110' },
+                      roster: {
+                        players: [
+                          { player: { player_id: 'sb1', name: { full: 'SlowStart' }, selected_position: 'QB', total_points: '5' } },
+                          { player: { player_id: 'sb2', name: { full: 'OKStart' }, selected_position: 'WR', total_points: '15' } },
+                          { player: { player_id: 'bb1', name: { full: 'BenchBoom' }, selected_position: 'BN', total_points: '25' } },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              matchup: {
+                teams: [
+                  {
+                    team: {
+                      team_id: '3',
+                      name: 'Crushers',
+                      managers: [{ manager: { nickname: 'Carl', guid: '3' } }],
+                      team_points: { total: '90' },
+                      roster: {
+                        players: [
+                          { player: { player_id: 'c1', name: { full: 'C1' }, selected_position: 'QB', total_points: '40' } },
+                          { player: { player_id: 'cb1', name: { full: 'CB1' }, selected_position: 'BN', total_points: '5' } },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    team: {
+                      team_id: '4',
+                      name: 'Dynamos',
+                      managers: [{ manager: { nickname: 'Dana', guid: '4' } }],
+                      team_points: { total: '91' },
+                      roster: {
+                        players: [
+                          { player: { player_id: 'd1', name: { full: 'D1' }, selected_position: 'QB', total_points: '42' } },
+                          { player: { player_id: 'db1', name: { full: 'DB1' }, selected_position: 'BN', total_points: '10' } },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+test('computeFacts works on Yahoo sample', () => {
+  const snapshot = toSnapshot({ leagueId: 'L1', name: 'Test League', season: '2024' }, 1, rawScoreboard);
+  const facts = computeFacts(snapshot);
+  assert.equal(facts.topScorer.team.teamId, '1');
+  assert.equal(facts.benchBlunder?.team.teamId, '2');
+  assert.equal(facts.waiverRoi?.team.teamId, '1');
+});

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -88,9 +88,47 @@ export const ZMatchupWeek = z
   })
   .strict();
 
+export const ZYahooMatchupWeek = z
+  .object({
+    platform: z.literal("yahoo"),
+    league: z.object({
+      platform: z.literal("yahoo"),
+      leagueId: z.string(),
+      season: z.number(),
+      name: z.string(),
+    }),
+    generatedAt: z.string(),
+    week: z.number(),
+    teams: z.array(
+      z.object({
+        teamId: z.string(),
+        displayName: z.string(),
+        ownerUserId: z.string(),
+      }),
+    ),
+    matchups: z.array(ZMatchup),
+    summary: z.object({
+      topScorerTeamId: z.string(),
+      topScorerPoints: z.number(),
+      biggestBlowoutGameId: z.string().nullable(),
+      closestGameId: z.string().nullable(),
+    }),
+    weeklyAwards: z.array(
+      z.object({
+        key: z.string(),
+        label: z.string(),
+        teamId: z.string().optional(),
+        value: z.number().optional(),
+        meta: z.record(z.unknown()).optional(),
+      }),
+    ),
+  })
+  .strict();
+
 export type SleeperUser = z.infer<typeof ZSleeperUser>;
 export type SleeperLeague = z.infer<typeof ZSleeperLeague>;
 export type SleeperMatchup = z.infer<typeof ZSleeperMatchup>;
 export type SleeperRoster = z.infer<typeof ZSleeperRoster>;
 export type SleeperUserMap = z.infer<typeof ZSleeperUserMap>;
 export type MatchupWeekSchema = z.infer<typeof ZMatchupWeek>;
+export type YahooMatchupWeekSchema = z.infer<typeof ZYahooMatchupWeek>;

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -1,12 +1,12 @@
 export type LeagueMeta = {
-  platform: "sleeper";
+  platform: "sleeper" | "yahoo";
   leagueId: string;
   season: number;
   name: string;
 };
 
 export type UserHandle = {
-  platform: "sleeper";
+  platform: "sleeper" | "yahoo";
   username: string;
 };
 
@@ -36,7 +36,7 @@ export type Matchup = {
 };
 
 export type MatchupWeek = {
-  platform: "sleeper";
+  platform: "sleeper" | "yahoo";
   league: LeagueMeta;
   generatedAt: string;
   week: number;


### PR DESCRIPTION
## Summary
- add Yahoo toSnapshot/toDomain utilities and resilient getLeagueWeek
- persist normalized Yahoo snapshots for computeFacts
- test Yahoo scoreboard computing weekly facts

## Testing
- `node --import tsx --test lib/providers/__tests__/yahoo.compute.test.ts`
- `npm test` *(fails: Module '"vitest"' has no exported member 'vi')*


------
https://chatgpt.com/codex/tasks/task_b_68b641b8b298832ea5b19169d20c982e