### PR TITLE
feat: polish script builder with hook and rivalries

### DIFF
--- a/lib/analysis/__tests__/script.test.ts
+++ b/lib/analysis/__tests__/script.test.ts
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildScript } from '../script';
+import { Facts } from '../../types';
+
+test('buildScript uses hook, nicknames, headlines and rivalries', () => {
+  const facts: Facts = {
+    week: 2,
+    leagueName: 'Test League',
+    teams: [
+      {
+        teamId: '1',
+        managerName: 'Alice',
+        teamName: 'Aces',
+        nickname: 'Aceholes',
+        pointsForWeek: 120,
+        pointsSeason: 300,
+      },
+      {
+        teamId: '2',
+        managerName: 'Bob',
+        teamName: 'Blitz',
+        nickname: 'Blitzy',
+        pointsForWeek: 100,
+        pointsSeason: 280,
+      },
+    ],
+    weeklyAwards: [{ key: 'top', label: 'Top Scorer', teamId: '1' }],
+    topScorer: { team: {
+      teamId: '1',
+      managerName: 'Alice',
+      teamName: 'Aces',
+      nickname: 'Aceholes',
+      pointsForWeek: 120,
+      pointsSeason: 300,
+    } },
+    upset: { winner: {
+      teamId: '1',
+      managerName: 'Alice',
+      teamName: 'Aces',
+      nickname: 'Aceholes',
+      pointsForWeek: 120,
+      pointsSeason: 300,
+    }, loser: {
+      teamId: '2',
+      managerName: 'Bob',
+      teamName: 'Blitz',
+      nickname: 'Blitzy',
+      pointsForWeek: 100,
+      pointsSeason: 280,
+    }, margin: 20 },
+    narrowLoss: undefined,
+    benchBlunder: undefined,
+    waiverRoi: undefined,
+    tradeImpact: undefined,
+    injuries: [],
+    rivalries: [ { teamA: 'Aceholes', teamB: 'Blitzy', historySummary: 'bad blood' } ],
+  };
+
+  const script = buildScript({
+    facts,
+    expert_headlines: ['Expert: Aceholes are title favorites.'],
+    rivalryOneLiners: ['Rivalry still red hot.'],
+  });
+
+  const lines = script.split('\n');
+  assert.ok(lines[0].includes('Aceholes'));
+  assert.ok(lines[0].includes('upset'));
+  assert.ok(script.includes('Aceholes') && script.includes('Blitzy'));
+  assert.ok(script.includes('Expert: Aceholes are title favorites.'));
+  assert.ok(script.includes('Rivalry still red hot.'));
+  assert.ok(script.includes('keep your pads low'));
+});

--- a/lib/analysis/compute.ts
+++ b/lib/analysis/compute.ts
@@ -62,6 +62,7 @@ export function computeFacts(snapshot: Snapshot): Facts {
     week: snapshot.week,
     leagueName: snapshot.leagueName,
     teams: snapshot.teams,
+    weeklyAwards: [],
     topScorer: { team: topTeam },
     upset,
     narrowLoss,

--- a/lib/analysis/script.ts
+++ b/lib/analysis/script.ts
@@ -1,26 +1,42 @@
-import { Facts } from '../types';
+import { Facts, Team } from '../types';
 
 export function buildScript({
   facts,
   expert_headlines,
+  rivalryOneLiners,
 }: {
   facts: Facts;
   expert_headlines: string[];
+  rivalryOneLiners?: string[];
 }): string {
   const lines: string[] = [];
+  const nameOf = (team: Team) => team.nickname ?? team.teamName;
+
+  const hookParts: string[] = [];
+  const firstAward = facts.weeklyAwards[0];
+  if (firstAward?.teamId) {
+    const team = facts.teams.find((t) => t.teamId === firstAward.teamId);
+    if (team) hookParts.push(`${nameOf(team)} earned ${firstAward.label}`);
+  }
+  if (facts.upset) {
+    hookParts.push(`${nameOf(facts.upset.winner)} upset ${nameOf(facts.upset.loser)}`);
+  } else if (facts.narrowLoss) {
+    hookParts.push(`${nameOf(facts.narrowLoss.loser)} fell by ${facts.narrowLoss.margin}`);
+  }
+  lines.push(hookParts.join(' — ') || 'Week highlights at a glance');
   lines.push(`# Week ${facts.week} Recap — ${facts.leagueName}`);
   lines.push(
-    `${facts.topScorer.team.managerName}'s ${facts.topScorer.team.teamName} slapped ${facts.topScorer.team.pointsForWeek} on the board.`
+    `${facts.topScorer.team.managerName}'s ${nameOf(facts.topScorer.team)} slapped ${facts.topScorer.team.pointsForWeek} on the board.`
   );
 
   if (facts.upset) {
     lines.push(
-      `Upset special: ${facts.upset.winner.teamName} shocked ${facts.upset.loser.teamName} by ${facts.upset.margin}.`
+      `Upset special: ${nameOf(facts.upset.winner)} shocked ${nameOf(facts.upset.loser)} by ${facts.upset.margin}.`
     );
   }
   if (facts.narrowLoss) {
     lines.push(
-      `Nail-biter: ${facts.narrowLoss.loser.teamName} lost by ${facts.narrowLoss.margin}.`
+      `Nail-biter: ${nameOf(facts.narrowLoss.loser)} lost by ${facts.narrowLoss.margin}.`
     );
   }
   if (facts.benchBlunder) {
@@ -37,8 +53,9 @@ export function buildScript({
     lines.push(`Injury watch: ${i.player} for ${i.team} is ${i.status}.`)
   );
   expert_headlines.forEach((h) => lines.push(h));
-  lines.push(
-    'This is Rick Romano—keep your pads low and your claims higher.'
-  );
+  if (facts.rivalries.length > 0 && rivalryOneLiners?.length) {
+    rivalryOneLiners.forEach((r) => lines.push(r));
+  }
+  lines.push('This is Rick Romano—keep your pads low and your claims higher.');
   return lines.join('\n');
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,7 @@ export interface Team {
   teamId: string;
   managerName: string;
   teamName: string;
+  nickname?: string;
   pointsForWeek: number;
   pointsSeason: number;
   starters?: Player[];
@@ -52,6 +53,13 @@ export interface Facts {
   week: number;
   leagueName: string;
   teams: Team[];
+  weeklyAwards: Array<{
+    key: string;
+    label: string;
+    teamId?: string;
+    value?: number;
+    meta?: Record<string, unknown>;
+  }>;
   topScorer: { team: Team };
   upset?: { winner: Team; loser: Team; margin: number };
   narrowLoss?: { winner: Team; loser: Team; margin: number };


### PR DESCRIPTION
## Summary
- expand script builder with nickname support, hook line, and rivalry one-liners
- allow Facts to carry weekly awards and team nicknames
- add unit test covering hook generation and rivalry injection

## Testing
- `npx tsx --test lib/analysis/__tests__/script.test.ts`
- `npm test` *(fails: Module '"vitest"' has no exported member 'vi')*

------
https://chatgpt.com/codex/tasks/task_b_68b6421eb204832eab479d8510e82344