### PR TITLE
Add runtime checks for Supabase admin client

### DIFF
--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="vitest" />
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({})
+  })
+}));
+
+import { getSupabaseAdmin } from '../db';
+
+describe('getSupabaseAdmin', () => {
+  it('returns client with from method', () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE = 'service-role-key';
+    const client = getSupabaseAdmin();
+    expect(typeof client.from).toBe('function');
+  });
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -18,13 +18,19 @@ export const getSupabase = (): SupabaseClient => {
 export const getSupabaseAdmin = (): SupabaseClient => {
   if (!_supabaseAdmin) {
     const url = process.env.SUPABASE_URL;
+    if (!url) {
+      throw new Error('Missing SUPABASE_URL environment variable');
+    }
     const service = process.env.SUPABASE_SERVICE_ROLE;
-    if (!url || !service) {
-      throw new Error('Missing Supabase service env vars');
+    if (!service) {
+      throw new Error('Missing SUPABASE_SERVICE_ROLE environment variable');
     }
     _supabaseAdmin = createClient(url, service, {
       auth: { persistSession: false },
     });
+    if (typeof _supabaseAdmin.from !== 'function') {
+      throw new Error('Supabase admin client failed to initialize');
+    }
   }
   return _supabaseAdmin;
 };

--- a/tests/snapshot.fetch.test.ts
+++ b/tests/snapshot.fetch.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="vitest" />
+
+const single = vi.fn().mockResolvedValue({ data: { access_token_enc: 'enc' }, error: null });
+const eq2 = vi.fn().mockReturnValue({ single });
+const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+const select = vi.fn().mockReturnValue({ eq: eq1 });
+const from = vi.fn().mockReturnValue({ select });
+
+vi.mock('@/lib/db', () => ({
+  getSupabaseAdmin: () => ({ from }),
+  upsertSnapshot: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/lib/security', () => ({
+  decryptToken: vi.fn().mockResolvedValue('token'),
+}));
+
+vi.mock('@/lib/providers/sleeper', () => ({
+  getLeagueWeek: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/lib/providers/yahoo', () => ({
+  getLeagueWeek: vi.fn(),
+  toSnapshot: vi.fn(),
+}));
+
+vi.mock('@/lib/metrics', () => ({
+  track: vi.fn(),
+  flush: vi.fn(),
+}));
+
+import { POST } from '../app/api/snapshot/fetch/route';
+
+describe('POST /api/snapshot/fetch', () => {
+  it('returns provided week on success', async () => {
+    const req = {
+      json: async () => ({ provider: 'sleeper', leagueId: '1', week: 7, userId: 'u' }),
+    } as any;
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, week: 7 });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Supabase admin client checks required env vars and exposes `from`
- cover Supabase admin getter and snapshot fetch route with tests

## Testing
- `npm test`
- `npx vitest run --config vitest.custom.config.ts lib/__tests__/db.test.ts tests/snapshot.fetch.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b649369874832ebae087090d62f9c9