### PR TITLE
Improve snapshot error handling and user feedback

### DIFF
--- a/app/api/snapshot/fetch/route.ts
+++ b/app/api/snapshot/fetch/route.ts
@@ -15,27 +15,67 @@ const lastCompletedWeek = (): number => {
 };
 
 export async function POST(req: NextRequest) {
+  // track env status for easier debugging without leaking secrets
+  const envStatus = {
+    node: process.env.NODE_ENV,
+    hasUrl: !!(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL),
+    hasServiceKey: !!process.env.SUPABASE_SERVICE_ROLE,
+  };
+
+  let provider: Provider | undefined;
+  let leagueId: string | undefined;
+
   try {
     const supabaseAdmin = getSupabaseAdmin();
-    const { provider, leagueId, week, userId } = await req.json();
+    const body = await req.json();
+    provider = body.provider;
+    leagueId = body.leagueId;
+    const { week, userId } = body;
+
     if (!provider || !leagueId) {
       return NextResponse.json({ ok: false, error: 'missing params' }, { status: 400 });
     }
     const fetchWeek = week || lastCompletedWeek();
-    const { data, error } = await supabaseAdmin
-      .from('league_connection')
-      .select('access_token_enc')
-      .eq('provider', provider)
-      .eq('league_id', leagueId)
-      .single();
-    if (error || !data) {
-      return NextResponse.json({ ok: false, error: 'no_token' }, { status: 400 });
+
+    let data: { access_token_enc: string } | null = null;
+    try {
+      const result = await supabaseAdmin
+        .from('league_connection')
+        .select('access_token_enc')
+        .eq('provider', provider)
+        .eq('league_id', leagueId)
+        .single();
+      data = result.data;
+      if (result.error || !data) {
+        return NextResponse.json({ ok: false, error: 'no_token' }, { status: 400 });
+      }
+    } catch (dbErr) {
+      console.error('[snapshot:fetch] supabase lookup failed', {
+        provider,
+        leagueId,
+        env: envStatus,
+        error: dbErr,
+      });
+      return NextResponse.json({ ok: false, error: 'supabase_lookup_failed' }, { status: 500 });
     }
+
     const access = await decryptToken(data.access_token_enc);
-    const snapshot =
-      provider === 'sleeper'
-        ? await sleeperData(leagueId, fetchWeek)
-        : await yahooData(access, leagueId, fetchWeek);
+
+    let snapshot: any;
+    try {
+      snapshot =
+        provider === 'sleeper'
+          ? await sleeperData(leagueId, fetchWeek)
+          : await yahooData(access, leagueId, fetchWeek);
+    } catch (snapErr) {
+      console.error('[snapshot:fetch] provider fetch failed', {
+        provider,
+        leagueId,
+        env: envStatus,
+        error: snapErr,
+      });
+      return NextResponse.json({ ok: false, error: 'snapshot_fetch_failed' }, { status: 500 });
+    }
 
     const toStore =
       provider === 'yahoo'
@@ -50,7 +90,18 @@ export async function POST(req: NextRequest) {
           )
         : snapshot;
 
-    await upsertSnapshot(provider, leagueId, fetchWeek, toStore);
+    try {
+      await upsertSnapshot(provider, leagueId, fetchWeek, toStore);
+    } catch (saveErr) {
+      console.error('[snapshot:fetch] snapshot save failed', {
+        provider,
+        leagueId,
+        env: envStatus,
+        error: saveErr,
+      });
+      return NextResponse.json({ ok: false, error: 'snapshot_save_failed' }, { status: 500 });
+    }
+
     track('snapshot_saved', userId, {
       provider,
       leagueId: leagueId,
@@ -59,6 +110,12 @@ export async function POST(req: NextRequest) {
     await flush();
     return NextResponse.json({ ok: true, week: fetchWeek });
   } catch (err: any) {
+    console.error('[snapshot:fetch] unexpected error', {
+      provider,
+      leagueId,
+      env: envStatus,
+      error: err,
+    });
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
   }
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -73,6 +73,20 @@ export default function Dashboard() {
     }
   }
 
+  // Map API errors to user-friendly guidance
+  function mapClientError(code: string) {
+    switch (code) {
+      case "supabase_lookup_failed":
+      case "Missing Supabase service env vars":
+      case "Missing Supabase client env vars":
+        return "Supabase not configured. Set SUPABASE_URL and service role key on the server.";
+      case "no_token":
+        return "No league connection found. Reconnect your provider account.";
+      default:
+        return code;
+    }
+  }
+
   // Read provider + auth error from URL
   useEffect(() => {
     const search = new URLSearchParams(window.location.search);
@@ -121,11 +135,11 @@ export default function Dashboard() {
         setLeagues(normalized);
       })
       .catch((e) => {
-        if (typeof e?.message === "string") {
-          setError(e.message);
-        } else {
-          setError("internal_error:unknown");
-        }
+        const msg =
+          typeof e?.message === "string"
+            ? mapClientError(e.message)
+            : "internal_error:unknown";
+        setError(msg);
       })
       .finally(() => {
         setLoadingLeagues(false);
@@ -210,13 +224,12 @@ export default function Dashboard() {
       setStatus("Episode ready! Redirecting...");
       router.push(`/e/${episodeId}`);
     } catch (e: any) {
-      if (typeof e?.message === "string") {
-        setError(e.message);
-        setStatus(`Error: ${e.message}`);
-      } else {
-        setError("internal_error:unknown");
-        setStatus("Error: internal_error:unknown");
-      }
+      const msg =
+        typeof e?.message === "string"
+          ? mapClientError(e.message)
+          : "internal_error:unknown";
+      setError(msg);
+      setStatus(`Error: ${msg}`);
     } finally {
       setLoadingEpisode(false);
     }
@@ -248,13 +261,12 @@ export default function Dashboard() {
       setStatus("Episode ready! Redirecting...");
       router.push(`/e/${episodeId}`);
     } catch (e: any) {
-      if (typeof e?.message === "string") {
-        setError(e.message);
-        setStatus(`Error: ${e.message}`);
-      } else {
-        setError("internal_error:unknown");
-        setStatus("Error: internal_error:unknown");
-      }
+      const msg =
+        typeof e?.message === "string"
+          ? mapClientError(e.message)
+          : "internal_error:unknown";
+      setError(msg);
+      setStatus(`Error: ${msg}`);
     } finally {
       setLoadingEpisode(false);
     }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -19,6 +19,10 @@ export const getSupabaseAdmin = (): SupabaseClient => {
   if (!_supabaseAdmin) {
     const url = process.env.SUPABASE_URL;
     const service = process.env.SUPABASE_SERVICE_ROLE;
+    console.log('[db] creating Supabase admin client', {
+      SUPABASE_URL: url ? 'present' : 'missing',
+      SUPABASE_SERVICE_ROLE: service ? 'present' : 'missing',
+    });
     if (!url || !service) {
       throw new Error('Missing Supabase service env vars');
     }


### PR DESCRIPTION
## Summary
- add detailed error logging for snapshot fetching, including environment status
- log Supabase admin client creation with env var presence
- surface friendly client-side error messages with setup guidance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b64938fff8832e9030c20845d36a99