### PR TITLE
Avoid fetching Yahoo leagues when authentication fails

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -94,7 +94,7 @@ export default function Dashboard() {
 
   // Fetch leagues when Yahoo is connected
   useEffect(() => {
-    if (provider !== "yahoo") return;
+    if (provider !== "yahoo" || authError) return;
 
     setError(null);
     setLeagues([]);
@@ -131,7 +131,7 @@ export default function Dashboard() {
         setLoadingLeagues(false);
         setStatus("");
       });
-  }, [provider]);
+  }, [provider, authError]);
 
   const handleYahoo = useYahooAuth();
   const handleSleeper = useSleeperAuth();


### PR DESCRIPTION
## Summary
- Skip fetching Yahoo leagues if authentication fails and include `authError` in effect dependencies

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b6496b2518832e928536e7e9032ccd