### PR TITLE
Handle Supabase admin init errors

### DIFF
--- a/app/api/leagues/list/route.ts
+++ b/app/api/leagues/list/route.ts
@@ -58,7 +58,12 @@ export async function GET(req: NextRequest) {
     console.log('[leagues:list] provider=yahoo');
 
     // A) Supabase admin
-    const supabase = getSupabaseAdmin?.();
+    let supabase: ReturnType<typeof getSupabaseAdmin>;
+    try {
+      supabase = getSupabaseAdmin();
+    } catch (err) {
+      return fail('supabase_admin_init', err);
+    }
     if (!supabase) return fail('supabase_admin_missing');
 
     // B) Load token row


### PR DESCRIPTION
## Summary
- catch Supabase admin initialization errors in leagues list route
- return `internal_error:supabase_admin_init` when Supabase admin fails to initialize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b64974bb20832e9233cea96c771465