### PR TITLE
feat: surface Yahoo OAuth errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# TypeScript build info
+tsconfig.tsbuildinfo

--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -56,9 +56,28 @@ export async function oauthExchange(code: string): Promise<YahooTokenResponse> {
 
   if (!res.ok) {
     let err: unknown;
-    try { err = await res.json(); } catch { err = await res.text(); }
+    try {
+      err = await res.json();
+    } catch {
+      err = await res.text();
+    }
+
+    // Log full error body for debugging
     console.error("Yahoo token exchange failed", res.status, err);
-    throw new Error("yahoo_oauth_exchange_failed");
+
+    // Propagate details so callers can surface actionable info
+    const detail =
+      err == null
+        ? ""
+        : typeof err === "string"
+        ? err
+        : JSON.stringify(err);
+
+    throw new Error(
+      detail
+        ? `yahoo_oauth_exchange_failed: ${detail}`
+        : "yahoo_oauth_exchange_failed",
+    );
   }
 
   return res.json();

--- a/tests/oauthExchange.test.ts
+++ b/tests/oauthExchange.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="vitest" />
+import { oauthExchange } from '../lib/providers/yahoo';
+
+// Ensure oauthExchange surfaces Yahoo error details to callers
+it('oauthExchange surfaces error detail', async () => {
+  process.env.YAHOO_CLIENT_ID = 'id';
+  process.env.YAHOO_CLIENT_SECRET = 'secret';
+  process.env.YAHOO_REDIRECT_URI = 'http://localhost';
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: false,
+    status: 400,
+    async json() {
+      return { error: 'bad auth' };
+    },
+    async text() {
+      return JSON.stringify({ error: 'bad auth' });
+    },
+  }) as any;
+
+  await expect(oauthExchange('code')).rejects.toThrow(
+    'yahoo_oauth_exchange_failed: {"error":"bad auth"}',
+  );
+
+  global.fetch = originalFetch;
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    include: ['tests/use*.test.ts']
+    include: ['tests/use*.test.ts', 'tests/oauthExchange.test.ts']
   }
 });


### PR DESCRIPTION
## Summary
- log full Yahoo OAuth error responses
- propagate Yahoo OAuth error details to callers
- add unit test for oauthExchange failure handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6497b098c832e8b29bd25e50bd33e