### PR TITLE
feat: validate env vars for yahoo and supabase

### DIFF
--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -8,6 +8,12 @@ import { oauthExchange } from '../../../../lib/providers/yahoo';
 import { encryptToken } from '../../../../lib/security';
 import { getSupabaseAdmin } from '../../../../lib/db';
 import { track } from '../../../../lib/metrics';
+import { validateEnv, YAHOO_ENV_VARS } from '../../../../lib/validateEnv';
+
+validateEnv(YAHOO_ENV_VARS);
+
+const clientId = process.env.YAHOO_CLIENT_ID!;
+const redirectUri = process.env.YAHOO_REDIRECT_URI!;
 
 /**
  * Build Yahoo OAuth authorize URL.
@@ -35,16 +41,6 @@ function buildAuth(clientId: string, redirectUri: string, state: string) {
  * Supports ?debug=1 to return the built URL as JSON instead of redirect.
  */
 export async function GET(req: NextRequest) {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-
-  if (!clientId || !redirectUri) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
-      { status: 500 }
-    );
-  }
-
   const url = new URL(req.url);
   const code = url.searchParams.get('code');
   const debug = url.searchParams.get('debug') === '1';
@@ -121,16 +117,6 @@ export async function GET(req: NextRequest) {
  * Return the built authorize URL as JSON (no redirect).
  */
 export async function POST(req: NextRequest) {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-
-  if (!clientId || !redirectUri) {
-    return NextResponse.json(
-      { ok: false, error: 'Missing YAHOO_CLIENT_ID or YAHOO_REDIRECT_URI' },
-      { status: 500 }
-    );
-  }
-
   const { uid, headers } = getOrCreateUid(req);
   const auth = buildAuth(clientId, redirectUri, uid);
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,15 +1,15 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { validateEnv, SUPABASE_ENV_VARS } from './validateEnv';
+
+validateEnv(SUPABASE_ENV_VARS);
 
 let _supabase: SupabaseClient | null = null;
 let _supabaseAdmin: SupabaseClient | null = null;
 
 export const getSupabase = (): SupabaseClient => {
   if (!_supabase) {
-    const url = process.env.SUPABASE_URL;
-    const anon = process.env.SUPABASE_ANON_KEY;
-    if (!url || !anon) {
-      throw new Error('Missing Supabase client env vars');
-    }
+    const url = process.env.SUPABASE_URL!;
+    const anon = process.env.SUPABASE_ANON_KEY!;
     _supabase = createClient(url, anon, { auth: { persistSession: false } });
   }
   return _supabase;
@@ -17,11 +17,8 @@ export const getSupabase = (): SupabaseClient => {
 
 export const getSupabaseAdmin = (): SupabaseClient => {
   if (!_supabaseAdmin) {
-    const url = process.env.SUPABASE_URL;
-    const service = process.env.SUPABASE_SERVICE_ROLE;
-    if (!url || !service) {
-      throw new Error('Missing Supabase service env vars');
-    }
+    const url = process.env.SUPABASE_URL!;
+    const service = process.env.SUPABASE_SERVICE_ROLE!;
     _supabaseAdmin = createClient(url, service, {
       auth: { persistSession: false },
     });

--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -3,6 +3,7 @@
 import { safeFetch } from "../http/safeFetch";
 import { ZYahooMatchupWeek } from "../schemas";
 import { z } from "zod";
+import { validateEnv, YAHOO_ENV_VARS } from "../validateEnv";
 import type {
   LeagueMeta,
   MatchupWeek,
@@ -17,8 +18,13 @@ import type {
   Matchup as SnapshotMatchup,
 } from "../types";
 
+validateEnv(YAHOO_ENV_VARS);
+
 const FANTASY_API = "https://fantasysports.yahooapis.com/fantasy/v2";
 const TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
+const clientId = process.env.YAHOO_CLIENT_ID!;
+const clientSecret = process.env.YAHOO_CLIENT_SECRET!;
+const redirectUri = process.env.YAHOO_REDIRECT_URI!;
 
 export interface YahooTokenResponse {
   access_token: string;
@@ -32,13 +38,6 @@ export type League = { leagueId: string; name: string; season: string };
 
 /** Exchange an authorization code for tokens. */
 export async function oauthExchange(code: string): Promise<YahooTokenResponse> {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const clientSecret = process.env.YAHOO_CLIENT_SECRET;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
-    throw new Error("Missing Yahoo OAuth env vars");
-  }
-
   const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
   const res = await fetch(TOKEN_URL, {
@@ -66,13 +65,6 @@ export async function oauthExchange(code: string): Promise<YahooTokenResponse> {
 
 /** Refresh an access token using a refresh_token. */
 export async function refreshToken(refresh_token: string): Promise<YahooTokenResponse> {
-  const clientId = process.env.YAHOO_CLIENT_ID;
-  const clientSecret = process.env.YAHOO_CLIENT_SECRET;
-  const redirectUri = process.env.YAHOO_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
-    throw new Error("Missing Yahoo OAuth env vars");
-  }
-
   const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
   const res = await fetch(TOKEN_URL, {

--- a/lib/validateEnv.ts
+++ b/lib/validateEnv.ts
@@ -1,0 +1,18 @@
+export function validateEnv(keys: readonly string[]): void {
+  const missing = keys.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required env vars: ${missing.join(', ')}`);
+  }
+}
+
+export const YAHOO_ENV_VARS = [
+  'YAHOO_CLIENT_ID',
+  'YAHOO_CLIENT_SECRET',
+  'YAHOO_REDIRECT_URI',
+] as const;
+
+export const SUPABASE_ENV_VARS = [
+  'SUPABASE_URL',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE',
+] as const;


### PR DESCRIPTION
## Summary
- validate Yahoo and Supabase env vars on startup
- centralize Yahoo OAuth config checks across API and provider
- ensure Supabase client only initializes when required vars are set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b64985be54832ebcd9fa462f0de10a