### PR TITLE
Refresh Yahoo tokens on expiry

### DIFF
--- a/app/api/leagues/list/route.ts
+++ b/app/api/leagues/list/route.ts
@@ -3,8 +3,12 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getOrCreateUid } from '../../../../lib/user';
 import { getSupabaseAdmin } from '../../../../lib/db';
-import { decryptToken } from '../../../../lib/security';
-import { listLeagues as yahooListLeagues } from '../../../../lib/providers/yahoo';
+import { decryptToken, encryptToken } from '../../../../lib/security';
+import {
+  listLeagues as yahooListLeagues,
+  refreshToken as yahooRefresh,
+} from '../../../../lib/providers/yahoo';
+import { FetchError } from '../../../../lib/http/safeFetch';
 
 export const runtime = 'nodejs';       // <— ensure Node, not Edge
 export const dynamic = 'force-dynamic';
@@ -79,15 +83,49 @@ export async function GET(req: NextRequest) {
 
     console.log('[leagues:list] token row found');
 
-    // C) Decrypt access token
+    // C) Decrypt tokens
     let accessToken: string;
+    let refreshToken: string | null = null;
     try {
       accessToken = await decryptToken(data.access_token_enc);
+      refreshToken = data.refresh_token_enc
+        ? await decryptToken(data.refresh_token_enc)
+        : null;
     } catch (e) {
       return fail('decrypt_access_token', e);
     }
 
     console.log('[leagues:list] token decrypted');
+
+    // Refresh if expired
+    const expired = data.expires_at
+      ? new Date(data.expires_at).getTime() <= Date.now()
+      : false;
+    if (expired && refreshToken) {
+      try {
+        const fresh = await yahooRefresh(refreshToken);
+        accessToken = fresh.access_token;
+        if (fresh.refresh_token) refreshToken = fresh.refresh_token;
+
+        const updates: Record<string, any> = {
+          access_token_enc: await encryptToken(accessToken),
+          expires_at: fresh.expires_in
+            ? new Date(Date.now() + fresh.expires_in * 1000).toISOString()
+            : null,
+        };
+        if (fresh.refresh_token) {
+          updates.refresh_token_enc = await encryptToken(fresh.refresh_token);
+        }
+        const { error: upErr } = await supabase
+          .from('league_connection')
+          .update(updates)
+          .eq('user_id', uid)
+          .eq('provider', 'yahoo');
+        if (upErr) return fail('db_update_tokens', upErr);
+      } catch (e) {
+        return fail('token_refresh', e, 401);
+      }
+    }
 
     // D) Yahoo leagues
     let leagues: League[] = [];
@@ -95,7 +133,36 @@ export async function GET(req: NextRequest) {
       const raw = await yahooListLeagues(accessToken);
       leagues = Array.isArray(raw) ? raw : [];
     } catch (e) {
-      return fail('yahoo_listLeagues', e);
+      if (e instanceof FetchError && e.status === 401 && refreshToken) {
+        try {
+          const fresh = await yahooRefresh(refreshToken);
+          accessToken = fresh.access_token;
+          if (fresh.refresh_token) refreshToken = fresh.refresh_token;
+
+          const updates: Record<string, any> = {
+            access_token_enc: await encryptToken(accessToken),
+            expires_at: fresh.expires_in
+              ? new Date(Date.now() + fresh.expires_in * 1000).toISOString()
+              : null,
+          };
+          if (fresh.refresh_token) {
+            updates.refresh_token_enc = await encryptToken(fresh.refresh_token);
+          }
+          const { error: upErr } = await supabase
+            .from('league_connection')
+            .update(updates)
+            .eq('user_id', uid)
+            .eq('provider', 'yahoo');
+          if (upErr) return fail('db_update_tokens', upErr);
+
+          const retry = await yahooListLeagues(accessToken);
+          leagues = Array.isArray(retry) ? retry : [];
+        } catch (e2) {
+          return fail('yahoo_listLeagues_refresh', e2);
+        }
+      } else {
+        return fail('yahoo_listLeagues', e);
+      }
     }
 
     console.log('[leagues:list] leagues ok:', leagues.length);


### PR DESCRIPTION
## Summary
- refresh Yahoo access tokens when `expires_at` is past or API returns 401
- persist updated tokens and expiry back to `league_connection`
- use `safeFetch` in Yahoo provider and propagate 401s

## Testing
- `YAHOO_CLIENT_ID=test YAHOO_CLIENT_SECRET=test YAHOO_REDIRECT_URI=http://localhost npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6e98a9254832e9639fe06e28bc3b3