### PR TITLE
docs: use single Yahoo auth callback path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ PLAYHT_USER_ID=
 # Yahoo: REQUIRED for OAuth
 YAHOO_CLIENT_ID=your_yahoo_client_id
 YAHOO_CLIENT_SECRET=your_yahoo_client_secret
-# Must exactly match Redirect URI configured in Yahoo Developer app
+# Must exactly match Redirect URI configured in Yahoo Developer app (use /api/auth/yahoo)
 YAHOO_REDIRECT_URI=https://your-domain.com/api/auth/yahoo
 
 # =========================

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ Minimal Next.js 14 + Tailwind starter with:
 - `/ok` health route
 - `/api/auth/sleeper` Sleeper OAuth redirect
 - `/api/auth/yahoo` Yahoo OAuth redirect
-- `/api/auth/*/callback` posts `{ provider, code }` to Make.com webhook
 
 ## Env vars (Vercel → Project → Settings → Environment Variables)
 - `SLEEPER_CLIENT_ID` / `SLEEPER_CLIENT_SECRET`
-- `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper/callback`
+- `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper`
 - `YAHOO_CLIENT_ID` / `YAHOO_CLIENT_SECRET`
-- `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo/callback`
+- `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo` (must match Yahoo Developer app)
 - `MAKE_CONNECTOR_URL` — your Make "connector.start" webhook URL
 - (optional) `NEXT_PUBLIC_MAKE_CONNECTOR_URL` — same as above if you prefer exposing to client
 

--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -13,6 +13,7 @@ import { validateEnv, YAHOO_ENV_VARS } from '../../../../lib/validateEnv';
 validateEnv(YAHOO_ENV_VARS);
 
 const clientId = process.env.YAHOO_CLIENT_ID!;
+// Redirect URI should be https://<your-domain>/api/auth/yahoo (no /callback)
 const redirectUri = process.env.YAHOO_REDIRECT_URI!;
 
 /**


### PR DESCRIPTION
## Summary
- clarify that Yahoo OAuth uses `/api/auth/yahoo` for both auth initiation and callback
- update example env vars and docs to match new redirect URI
- note the expected redirect in Yahoo auth route

## Testing
- `YAHOO_CLIENT_ID=dummy YAHOO_CLIENT_SECRET=dummy YAHOO_REDIRECT_URI=http://localhost/api/auth/yahoo npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6e998c0c4832eaa817d952b4f10af