### PR TITLE
Normalize Yahoo redirect URI and document usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ PLAYHT_USER_ID=
 # Yahoo: REQUIRED for OAuth
 YAHOO_CLIENT_ID=your_yahoo_client_id
 YAHOO_CLIENT_SECRET=your_yahoo_client_secret
-# Must exactly match Redirect URI configured in Yahoo Developer app (use /api/auth/yahoo)
+# Must exactly match Redirect URI configured in Yahoo Developer app (use /api/auth/yahoo, no trailing slash)
 YAHOO_REDIRECT_URI=https://your-domain.com/api/auth/yahoo
 
 # =========================

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimal Next.js 14 + Tailwind starter with:
 - `SLEEPER_CLIENT_ID` / `SLEEPER_CLIENT_SECRET`
 - `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper`
 - `YAHOO_CLIENT_ID` / `YAHOO_CLIENT_SECRET`
-- `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo` (must match Yahoo Developer app)
+- `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo` (must match Yahoo Developer app, no trailing slash)
 - `MAKE_CONNECTOR_URL` — your Make "connector.start" webhook URL
 - (optional) `NEXT_PUBLIC_MAKE_CONNECTOR_URL` — same as above if you prefer exposing to client
 

--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -24,7 +24,8 @@ const FANTASY_API = "https://fantasysports.yahooapis.com/fantasy/v2";
 const TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
 const clientId = process.env.YAHOO_CLIENT_ID!;
 const clientSecret = process.env.YAHOO_CLIENT_SECRET!;
-const redirectUri = process.env.YAHOO_REDIRECT_URI!;
+// Normalize to avoid trailing slash mismatches
+const redirectUri = process.env.YAHOO_REDIRECT_URI!.replace(/\/+$/, "");
 
 export interface YahooTokenResponse {
   access_token: string;
@@ -35,6 +36,18 @@ export interface YahooTokenResponse {
 }
 
 export type League = { leagueId: string; name: string; season: string };
+
+/** Build Yahoo OAuth authorize URL. */
+export function buildAuth(state: string) {
+  const auth = new URL("https://api.login.yahoo.com/oauth2/request_auth");
+  auth.searchParams.set("client_id", clientId);
+  auth.searchParams.set("redirect_uri", redirectUri);
+  auth.searchParams.set("response_type", "code");
+  auth.searchParams.set("scope", "fspt-r");
+  auth.searchParams.set("language", "en-us");
+  auth.searchParams.set("state", state);
+  return auth;
+}
 
 /** Exchange an authorization code for tokens. */
 export async function oauthExchange(code: string): Promise<YahooTokenResponse> {

--- a/tests/oauthExchange.test.ts
+++ b/tests/oauthExchange.test.ts
@@ -1,11 +1,12 @@
 /// <reference types="vitest" />
-import { oauthExchange } from '../lib/providers/yahoo';
 
 // Ensure oauthExchange surfaces Yahoo error details to callers
 it('oauthExchange surfaces error detail', async () => {
   process.env.YAHOO_CLIENT_ID = 'id';
   process.env.YAHOO_CLIENT_SECRET = 'secret';
   process.env.YAHOO_REDIRECT_URI = 'http://localhost';
+
+  const { oauthExchange } = await import('../lib/providers/yahoo');
 
   const originalFetch = global.fetch;
   global.fetch = async () => ({
@@ -25,3 +26,4 @@ it('oauthExchange surfaces error detail', async () => {
 
   global.fetch = originalFetch;
 });
+


### PR DESCRIPTION
## Summary
- sanitize YAHOO_REDIRECT_URI and reuse across Yahoo OAuth flows
- centralize Yahoo auth URL builder
- document that YAHOO_REDIRECT_URI must not include a trailing slash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6f97eb50c832e8d61ec490b684869