### PR TITLE
Ensure Yahoo OAuth requests permanent tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ YAHOO_CLIENT_ID=your_yahoo_client_id
 YAHOO_CLIENT_SECRET=your_yahoo_client_secret
 # Must exactly match Redirect URI configured in Yahoo Developer app (use /api/auth/yahoo, no trailing slash)
 YAHOO_REDIRECT_URI=https://your-domain.com/api/auth/yahoo
+# Yahoo refresh tokens require adding duration=permanent to the authorize URL
 
 # =========================
 # Optional webhooks / no-code integrations

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Minimal Next.js 14 + Tailwind starter with:
 - `SLEEPER_REDIRECT_URI` — `https://<your-domain>/api/auth/sleeper`
 - `YAHOO_CLIENT_ID` / `YAHOO_CLIENT_SECRET`
 - `YAHOO_REDIRECT_URI` — `https://<your-domain>/api/auth/yahoo` (must match Yahoo Developer app, no trailing slash)
+- Yahoo refresh tokens require adding `duration=permanent` to the Yahoo authorize URL
 - `MAKE_CONNECTOR_URL` — your Make "connector.start" webhook URL
 - (optional) `NEXT_PUBLIC_MAKE_CONNECTOR_URL` — same as above if you prefer exposing to client
 

--- a/lib/providers/yahoo.ts
+++ b/lib/providers/yahoo.ts
@@ -45,6 +45,7 @@ export function buildAuth(state: string) {
   auth.searchParams.set("response_type", "code");
   auth.searchParams.set("scope", "fspt-r");
   auth.searchParams.set("language", "en-us");
+  auth.searchParams.set("duration", "permanent");
   auth.searchParams.set("state", state);
   return auth;
 }


### PR DESCRIPTION
## Summary
- request Yahoo OAuth tokens with `duration=permanent` to enable refresh token issuance
- document Yahoo's `duration=permanent` requirement in README and `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b706db1e20832ea6c8611ec1bc6ee5