### PR TITLE
fix: ensure safeUid fallback sets cookie

### DIFF
--- a/app/api/leagues/list/route.ts
+++ b/app/api/leagues/list/route.ts
@@ -37,7 +37,7 @@ function safeUid(req: NextRequest) {
     // Fallback: synthesize a uid and set-cookie ourselves
     const synthetic = crypto.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
     const headers = {
-      'set-cookie': `uid=${encodeURIComponent(synthetic)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+      'Set-Cookie': `uid=${encodeURIComponent(synthetic)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
     };
     console.warn('[leagues:list] safeUid fallback used');
     return { uid: synthetic, headers };

--- a/tests/useSafeUidFallback.test.ts
+++ b/tests/useSafeUidFallback.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="vitest" />
+import { NextRequest } from 'next/server';
+
+vi.mock('../lib/user', () => {
+  return {
+    getOrCreateUid: () => {
+      throw new Error('boom');
+    },
+  };
+});
+
+vi.mock('../lib/db', () => {
+  return {
+    getSupabaseAdmin: () => {
+      throw new Error('should not call');
+    },
+  };
+});
+
+vi.mock('../lib/providers/yahoo', () => ({
+  listLeagues: async () => [],
+  refreshToken: async () => ({ access_token: '', refresh_token: '', expires_in: 0 }),
+}));
+
+describe('safeUid fallback', () => {
+  it('sets uid cookie when getOrCreateUid throws', async () => {
+    const { GET } = await import('../app/api/leagues/list/route');
+    const req = new NextRequest('http://example.com/api/leagues/list?provider=sleeper');
+    const res = await GET(req as any);
+    const cookie = res.headers.get('set-cookie');
+    expect(cookie).toBeTruthy();
+    expect(cookie).toContain('uid=');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure leagues list safeUid fallback uses `Set-Cookie`
- add tests verifying fallback sets uid cookie

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b706ec6144832e822717b0f2806060