### PR TITLE
feat: ensure app user before yahoo league connection

### DIFF
--- a/app/api/auth/yahoo/route.ts
+++ b/app/api/auth/yahoo/route.ts
@@ -3,7 +3,7 @@ export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getOrCreateUid } from '../../../../lib/user';
+import { getOrCreateUid, ensureAppUser } from '../../../../lib/user';
 import { buildAuth, oauthExchange } from '../../../../lib/providers/yahoo';
 import { encryptToken } from '../../../../lib/security';
 import { getSupabaseAdmin } from '../../../../lib/db';
@@ -33,6 +33,7 @@ export async function GET(req: NextRequest) {
     try {
       const tokens = await oauthExchange(code); // implemented in lib/providers/yahoo.ts
       if (tokens && uid) {
+        await ensureAppUser(uid);
         const supabase = getSupabaseAdmin();
         const access_enc = await encryptToken(tokens.access_token);
         const refresh_enc = tokens.refresh_token

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import { getSupabaseAdmin } from './db';
 
 function parseCookie(cookieHeader: string | null): Record<string, string> {
   if (!cookieHeader) return {};
@@ -41,3 +42,14 @@ export function getOrCreateUid(
     headers: { 'Set-Cookie': cookie },
   };
 }
+
+export const ensureAppUser = async (uid: string): Promise<void> => {
+  const { error } = await getSupabaseAdmin()
+    .from('app_user')
+    .upsert({ id: uid }, { onConflict: 'id' });
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error('ensureAppUser upsert error:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add ensureAppUser helper to create placeholder app_user records
- use ensureAppUser before storing Yahoo league tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b706eac864832e9617d4dbf277fa19